### PR TITLE
Fix to install Cartopy dependencies in CI

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -9,6 +9,11 @@ jobs:
     name: Check Python Coding Norms
     runs-on: ubuntu-latest
     steps:
+    - name: Install ubuntu dependencies
+      run: |
+        sudo apt-get install libproj-dev proj-data proj-bin
+        sudo apt-get install libgeos-dev musl-dev libc-dev
+        sudo ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
## Description

Cartopy has dependencies that are annoying to install. Normally, conda handles this, but ubuntu on GitHub actions allows us to just do `sudo apt-get`