### PR TITLE
Link to docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,37 +14,7 @@ Aeronautics and Space Administration. All Rights Reserved.
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
+### Documentation
 
-### Installation
-
-The eva package can be installed using pip:
-
-	pip install --prefix=/path/to/install/ .
-
-### Usage
-
-eva uses a strict dictionary/configuration only API. This ensures flexible use for different applications. The most straightforward use of eva is achieved by passing it a YAML configuration file on the command line:
-
-	eva obs_correlation.yaml
-
-Where the YAML must contain a list of the diagnostics to be used in the following format:
-
-```
-diagnostics:
-  - diagnostic name: ObsCorrelationScatter
-    ...
-  - diagnostic name: ObsMapScatter
-    ...
-```
-
-eva can also be invoked from another Python module that passes it a dictionary, rather than a YAML file that is later translated into a dictionary. This is achieved as follows:
-
-```
-from eva.eva_base import eva
-
-eva(eva_dict)
-```
-
-The dictionary must take the same hierarchy as shown above in the YAML file, i.e. with a list of diagnostics to be run. Note that the calling routine can still pass a string with a path to the YAML file if so desired.
-
-Note that eva can also be invoked within Jupyter notebooks using the above API.
+Documentation for Eva, which includes installation instructions, can be found at
+https://danholdaway.github.io/eva.


### PR DESCRIPTION
## Description

I've added a place where we can start to add documentation, which I feel will be fairly important to have in place before we start inviting people to contribute more diagnostics or plot tools. This PR just changes the README to link to it instead of providing instructions.

It uses Docsify, which means there is no need to build a webpage, as is the case with Sphinx/RTD. You simply push changes to the files in the gh-pages branch and it will update the page within a few minutes. To my mind this makes for much easier adding of documentation. I've put the docs on a gh-pages branch instead of to develop since that negates the need to run CI each time we need to change the docs. But open to hearing differing opinions on that.