### PR TITLE
Create nlocs using range

### DIFF
--- a/src/eva/data/ioda_obs_space.py
+++ b/src/eva/data/ioda_obs_space.py
@@ -40,6 +40,7 @@ def subset_channels(ds, channels, add_channels_variable=False):
 
 # --------------------------------------------------------------------------------------------------
 
+
 def check_nlocs(nlocs):
     if max(nlocs) == 0:
         new_nlocs = range(nlocs.size)

--- a/src/eva/data/ioda_obs_space.py
+++ b/src/eva/data/ioda_obs_space.py
@@ -40,6 +40,14 @@ def subset_channels(ds, channels, add_channels_variable=False):
 
 # --------------------------------------------------------------------------------------------------
 
+def check_nlocs(nlocs):
+    if max(nlocs) == 0:
+        new_nlocs = range(nlocs.size)
+        nlocs = new_nlocs + nlocs
+    return nlocs
+
+# --------------------------------------------------------------------------------------------------
+
 
 class IodaObsSpace(EvaBase):
 
@@ -74,6 +82,9 @@ class IodaObsSpace(EvaBase):
 
                 # Get file header
                 ds_header = xr.open_dataset(filename)
+
+                # fix nlocs if they are all zeros
+                ds_header['nlocs'] = check_nlocs(ds_header['nlocs'])
 
                 # Read header part of the file to get coordinates
                 ds_groups = xr.Dataset()


### PR DESCRIPTION
With recent (all new?) IODA output files, nlocs is all zeros, which causes issues when combining xarray datasets.

This PR will check if the max value of `nlocs` is zero for ioda_obs_space, if so, it will use `range` combined with `nlocs.size` and add 0 ... nlocs to the 0 values so that there are unique values for each location.

Tested on Orion and it fixes my issue. See the plot of AMSU-A using output from a recent run of H(x) from 'GDASApp'.
![Screenshot from 2022-05-20 20-36-14](https://user-images.githubusercontent.com/6354668/169606973-7ef5de65-38cd-4310-9584-2b2d04521209.png)

