### PR TITLE
Some minor bugfixes

### DIFF
--- a/src/eva/diagnostics/scatter.py
+++ b/src/eva/diagnostics/scatter.py
@@ -36,11 +36,13 @@ class Scatter():
 
         # Remove NaN values to enable regression
         # --------------------------------------
-        xdata = xdata[~np.isnan(xdata)]
-        ydata = ydata[~np.isnan(xdata)]
+        mask = ~np.isnan(xdata)
+        xdata = xdata[mask]
+        ydata = ydata[mask]
 
-        xdata = xdata[~np.isnan(ydata)]
-        ydata = ydata[~np.isnan(ydata)]
+        mask = ~np.isnan(ydata)
+        xdata = xdata[mask]
+        ydata = ydata[mask]
 
         # Create declarative plotting Scatter object
         # ------------------------------------------

--- a/src/eva/plot_tools/figure_driver.py
+++ b/src/eva/plot_tools/figure_driver.py
@@ -117,8 +117,7 @@ class FigureDriver(EvaBase):
         return out_conf
 
     def get_output_file(self, figure_conf):
-        file_type = figure_conf.get("figure file type", "png")
         file_path = figure_conf.get("output path", "./")
         output_name = figure_conf.get("output name", "")
-        output_file = os.path.join(file_path, f"{output_name}.{file_type}")
+        output_file = os.path.join(file_path, output_name)
         return output_file


### PR DESCRIPTION
Two bugfixes:
1) when masking out `nan` values in the scatter plot, the size of x would change and then be different from y, leading to an error. The mask is now computed before the slicing, so that the mask stays the same size.
2) `.png` was added 2x to the filepaths, because the code was adding `figure file type` as the extension. This has been removed so now the user has to ensure `.png` is in the YAML specified output path.