### PR TITLE
Add option to normalize the color map for integer fields

### DIFF
--- a/src/eva/plot_tools/figure.py
+++ b/src/eva/plot_tools/figure.py
@@ -1,6 +1,7 @@
 # This work developed by NOAA/NWS/EMC under the Apache 2.0 license.
 import os
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 import cartopy.crs as ccrs
@@ -149,9 +150,14 @@ class CreateFigure:
 
     def _map_scatter(self, plotobj, ax):
 
+        # Flag set for integer fields
+        integer_field = False
+        if 'integer_field' in vars(plotobj):
+            integer_field = True
+
         if plotobj.data is None:
             skipvars = ['plottype', 'longitude', 'latitude',
-                        'markersize']
+                        'markersize', 'integer_field']
             inputs = self._get_inputs_dict(skipvars, plotobj)
 
             cs = ax.scatter(plotobj.longitude, plotobj.latitude,
@@ -159,11 +165,22 @@ class CreateFigure:
                             transform=self.projection.projection)
         else:
             skipvars = ['plottype', 'longitude', 'latitude',
-                        'data', 'markersize', 'colorbar']
+                        'data', 'markersize', 'colorbar', 'normalize', 'integer_field']
             inputs = self._get_inputs_dict(skipvars, plotobj)
+
+            norm = None
+            if integer_field:
+                cmap = matplotlib.cm.get_cmap(inputs['cmap'])
+                vmin = inputs['vmin']
+                vmax = inputs['vmax']
+                if vmin is None or vmax is None:
+                    print("Abort: vmin and vmax must be set for integer fields")
+                    exit()
+                norm = matplotlib.colors.BoundaryNorm(np.arange(vmin-0.5,vmax,1), cmap.N)
+
             cs = ax.scatter(plotobj.longitude, plotobj.latitude,
                             c=plotobj.data, s=plotobj.markersize,
-                            **inputs, transform=self.projection.projection)
+                            **inputs, norm=norm, transform=self.projection.projection)
         if plotobj.colorbar:
             self.cs = cs
 
@@ -359,6 +376,7 @@ class CreateFigure:
                     cb.set_label(colorbar['label'], fontsize=colorbar['fontsize'])
 
             else:
+                print('colorbarcolorbar', colorbar)
                 cb = self.fig.colorbar(self.cs, ax=ax,
                                        **colorbar['kwargs'])
                 cb.set_label(colorbar['label'], fontsize=colorbar['fontsize'])

--- a/src/eva/plot_tools/figure.py
+++ b/src/eva/plot_tools/figure.py
@@ -176,7 +176,7 @@ class CreateFigure:
                 if vmin is None or vmax is None:
                     print("Abort: vmin and vmax must be set for integer fields")
                     exit()
-                norm = matplotlib.colors.BoundaryNorm(np.arange(vmin-0.5, vmax, 1), cmap.N)
+                norm = matplotlib.colors.BoundaryNorm(np.arange(vmin-0.5,vmax,1), cmap.N)
 
             cs = ax.scatter(plotobj.longitude, plotobj.latitude,
                             c=plotobj.data, s=plotobj.markersize,
@@ -376,7 +376,6 @@ class CreateFigure:
                     cb.set_label(colorbar['label'], fontsize=colorbar['fontsize'])
 
             else:
-                print('colorbarcolorbar', colorbar)
                 cb = self.fig.colorbar(self.cs, ax=ax,
                                        **colorbar['kwargs'])
                 cb.set_label(colorbar['label'], fontsize=colorbar['fontsize'])
@@ -701,3 +700,4 @@ class CreatePlot():
                              f'choices are: {" | ".join(valid_scales)}')
 
         self.yscale = scale
+  

--- a/src/eva/plot_tools/figure.py
+++ b/src/eva/plot_tools/figure.py
@@ -700,4 +700,3 @@ class CreatePlot():
                              f'choices are: {" | ".join(valid_scales)}')
 
         self.yscale = scale
-  

--- a/src/eva/plot_tools/figure.py
+++ b/src/eva/plot_tools/figure.py
@@ -176,7 +176,7 @@ class CreateFigure:
                 if vmin is None or vmax is None:
                     print("Abort: vmin and vmax must be set for integer fields")
                     exit()
-                norm = matplotlib.colors.BoundaryNorm(np.arange(vmin-0.5,vmax,1), cmap.N)
+                norm = matplotlib.colors.BoundaryNorm(np.arange(vmin-0.5, vmax, 1), cmap.N)
 
             cs = ax.scatter(plotobj.longitude, plotobj.latitude,
                             c=plotobj.data, s=plotobj.markersize,

--- a/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
@@ -222,13 +222,127 @@ diagnostics:
 
     - batch figure:
         variables:
-        - average_surface_temperature_within_field_of_view
+        - vegetation_type_index
+      figure:
+        layout: [2,1]
+        figure size: [40,24]
+        output name: surface_geovals/gsi_vs_jedi_map_amsua_n19_${variable}.png
+        tight_layout: true
+      plots:
+        - add_title: 'GSI GeoVaLs ${variable}'
+          mapping:
+            projection: plcarr
+            domain: global
+          add_map_features: ['coastline']
+          add_colorbar:
+            label: '${variable}'
+            ticks: [1,2,3,4,5,6,7,8,9,10,11,12,13]
+          add_grid:
+          layers:
+          - type: MapScatter
+            longitude:
+              variable: experiment::MetaData::longitude
+            latitude:
+              variable: experiment::MetaData::latitude
+            data:
+              variable: experiment::GsiGeoVaLs::${variable}
+            markersize: 2
+            label: '$(variable)'
+            colorbar: true
+            cmap: 'rainbow'
+            vmin: 1
+            vmax: 14
+            integer_field:
+        - add_title: 'JEDI GeoVaLs ${variable}'
+          mapping:
+            projection: plcarr
+            domain: global
+          add_map_features: ['coastline']
+          add_colorbar:
+            label: '${variable}'
+            ticks: [1,2,3,4,5,6,7,8,9,10,11,12,13]
+          add_grid:
+          layers:
+          - type: MapScatter
+            longitude:
+              variable: experiment::MetaData::longitude
+            latitude:
+              variable: experiment::MetaData::latitude
+            data:
+              variable: experiment::GeoVaLs::${variable}
+            markersize: 2
+            label: '${variable}'
+            colorbar: true
+            cmap: 'rainbow'
+            vmin: 1
+            vmax: 14
+            integer_field:
+
+    - batch figure:
+        variables:
         - soil_type
+      figure:
+        layout: [2,1]
+        figure size: [40,24]
+        output name: surface_geovals/gsi_vs_jedi_map_amsua_n19_${variable}.png
+        tight_layout: true
+      plots:
+        - add_title: 'GSI GeoVaLs ${variable}'
+          mapping:
+            projection: plcarr
+            domain: global
+          add_map_features: ['coastline']
+          add_colorbar:
+            label: '${variable}'
+            ticks: [1,2,3,4,5,6,7,8,9]
+          add_grid:
+          layers:
+          - type: MapScatter
+            longitude:
+              variable: experiment::MetaData::longitude
+            latitude:
+              variable: experiment::MetaData::latitude
+            data:
+              variable: experiment::GsiGeoVaLs::${variable}
+            markersize: 2
+            label: '$(variable)'
+            colorbar: true
+            cmap: 'rainbow'
+            vmin: 1
+            vmax: 10
+            integer_field:
+        - add_title: 'JEDI GeoVaLs ${variable}'
+          mapping:
+            projection: plcarr
+            domain: global
+          add_map_features: ['coastline']
+          add_colorbar:
+            label: '${variable}'
+            ticks: [1,2,3,4,5,6,7,8,9]
+          add_grid:
+          layers:
+          - type: MapScatter
+            longitude:
+              variable: experiment::MetaData::longitude
+            latitude:
+              variable: experiment::MetaData::latitude
+            data:
+              variable: experiment::GeoVaLs::${variable}
+            markersize: 2
+            label: '${variable}'
+            colorbar: true
+            cmap: 'rainbow'
+            vmin: 1
+            vmax: 10
+            integer_field:
+
+    - batch figure:
+        variables:
+        - average_surface_temperature_within_field_of_view
         - surface_temperature_where_ice
         - surface_temperature_where_land
         - surface_temperature_where_sea
         - surface_temperature_where_snow
-        - vegetation_type_index
       figure:
         layout: [2,1]
         figure size: [40,24]


### PR DESCRIPTION
## Description

Allows for plots like the attached, where the colorbar is normalized. Useful for plotting integer fields.
![gsi_vs_jedi_map_amsua_n19_vegetation_type_index](https://user-images.githubusercontent.com/27729500/173442272-d6b72edd-ba59-48e3-94ab-fa2bc112ec1b.jpg)

