### PR TITLE
Modify regex split

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -13,6 +13,7 @@ jobs:
       run: |
         sudo apt-get install libproj-dev proj-data proj-bin
         sudo apt-get install libgeos-dev musl-dev libc-dev
+        sudo apt-get install libcurl4-openssl-dev
         sudo ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1
         mkdir proj && cd proj
         curl -sSL https://download.osgeo.org/proj/proj-8.2.1.tar.gz | tar -xvz

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -13,7 +13,6 @@ jobs:
       run: |
         sudo apt-get install libproj-dev proj-data proj-bin
         sudo apt-get install libgeos-dev musl-dev libc-dev
-        sudo apt-get install libcurl4-openssl-dev
         sudo ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -14,6 +14,13 @@ jobs:
         sudo apt-get install libproj-dev proj-data proj-bin
         sudo apt-get install libgeos-dev musl-dev libc-dev
         sudo ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1
+        mkdir proj && cd proj
+        curl -sSL https://download.osgeo.org/proj/proj-8.2.1.tar.gz | tar -xvz
+        cd proj-8.2.1
+        mkdir build && cd build
+        cmake ..
+        cmake --build .
+        sudo cmake --build . --target install
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -15,17 +15,10 @@ jobs:
         sudo apt-get install libgeos-dev musl-dev libc-dev
         sudo apt-get install libcurl4-openssl-dev
         sudo ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1
-        mkdir proj && cd proj
-        curl -sSL https://download.osgeo.org/proj/proj-8.2.1.tar.gz | tar -xvz
-        cd proj-8.2.1
-        mkdir build && cd build
-        cmake ..
-        cmake --build .
-        sudo cmake --build . --target install
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
         python-version: '3.9'
         cache: 'pip'
-    - run: pip install -r requirements.txt
+    - run: pip install --use-deprecated=legacy-resolver -r requirements.txt
     - run: python3 pycodestyle_run.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pyyaml>=5.4
 pycodestyle>=2.8.0
 netCDF4>=1.5.7
 matplotlib>=3.4.3
-cartopy==0.20.2
+cartopy==0.19.0rc1
 scikit-learn>=1.0.2
 xarray>=0.11.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pyyaml>=5.4
 pycodestyle>=2.8.0
 netCDF4>=1.5.7
 matplotlib>=3.4.3
-cartopy==0.19.0.post1
+cartopy==0.20.2
 scikit-learn>=1.0.2
 xarray>=0.11.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pyyaml>=5.4
 pycodestyle>=2.8.0
 netCDF4>=1.5.7
 matplotlib>=3.4.3
-cartopy>=0.20
+cartopy==0.19.0.post1
 scikit-learn>=1.0.2
 xarray>=0.11.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pyyaml>=5.4
 pycodestyle>=2.8.0
 netCDF4>=1.5.7
 matplotlib>=3.4.3
-cartopy==0.19.0rc1
+cartopy>=0.20
 scikit-learn>=1.0.2
 xarray>=0.11.3

--- a/src/eva/transforms/arithmetic.py
+++ b/src/eva/transforms/arithmetic.py
@@ -50,7 +50,7 @@ def arithmetic(config, data_collections):
                 expression = ''.join(expression.split())
 
                 # Split math equation
-                expression_elements = re.split(r'\(|\)|-|\*|\+|\/|mean|sqrt|\d', expression)
+                expression_elements = re.split(r'\(|\)|-|\*|\+|\/', expression)
 
                 # Remove empty elements and duplicates from expression elements
                 expression_elements = remove_empty_from_list_of_strings(expression_elements)


### PR DESCRIPTION
Closes #33 

This removes `mean`, `sqrt`, and `\d` from the `regex.split` command for the arithmetic.

Currently, if a variable/group/collection contains a number or 'mean' or 'sqrt' in its name, it will fail. This should fix that. However, we will still need a solution eventually for dealing with 'functions' (mean, sqrt, others)