### PR TITLE
Add initial histogram support

### DIFF
--- a/src/eva/defaults/histogram.yaml
+++ b/src/eva/defaults/histogram.yaml
@@ -1,0 +1,16 @@
+# Histogram class default schema
+bins: 10
+range:
+density: false
+weights:
+cumulative: false
+bottom:
+histtype: 'bar'
+align: 'mid'
+orientation: 'vertical'
+rwidth:
+log: false
+color: 'tab:blue'
+label:
+stacked: false
+alpha:

--- a/src/eva/diagnostics/histogram.py
+++ b/src/eva/diagnostics/histogram.py
@@ -12,7 +12,7 @@ class Histogram():
 
         # Get the data to plot from the data_collection
         # ---------------------------------------------
-        varstr = config['variable']
+        varstr = config['data']['variable']
         var_cgv = varstr.split('::')
 
         if len(var_cgv) != 3:
@@ -22,7 +22,31 @@ class Histogram():
 
         # Optionally get the channel to plot
         channel = None
-        if 'channel' in config:
+        if 'channel' in config['data']:
             channel = config.get('channel')
 
         data = dataobj.get_variable_data(var_cgv[0], var_cgv[1], var_cgv[2], channel)
+
+        # See if we need to slice data
+        data = slice_var_from_str(config['data'], data, logger)
+
+        # Histogram data should be flattened
+        data = data.flatten()
+
+        # Missing data should also be removed
+        mask = ~np.isnan(data)
+        data = data[mask]
+
+        # Create declarative plotting histogram object
+        # --------------------------------------------
+        self.plotobj = eva.plot_tools.plots.Histogram(data)
+
+        # Get defaults from schema
+        # ------------------------
+        layer_schema = config.get('schema', os.path.join(return_eva_path(), 'defaults',
+                                  'histogram.yaml'))
+        config = get_schema(layer_schema, config, logger)
+        delvars = ['type', 'schema', 'data']
+        for d in delvars:
+            config.pop(d, None)
+        self.plotobj = update_object(self.plotobj, config, logger)

--- a/src/eva/diagnostics/histogram.py
+++ b/src/eva/diagnostics/histogram.py
@@ -1,0 +1,28 @@
+from eva.eva_path import return_eva_path
+from eva.utilities.config import get
+from eva.utilities.utils import get_schema, update_object, slice_var_from_str
+import eva.plot_tools.plots
+import os
+import numpy as np
+
+
+class Histogram():
+
+    def __init__(self, config, logger, dataobj):
+
+        # Get the data to plot from the data_collection
+        # ---------------------------------------------
+        varstr = config['variable']
+        var_cgv = varstr.split('::')
+
+        if len(var_cgv) != 3:
+            logger.abort('In Histogram the variable \'var_cgv\' does not appear to '+
+                         'be in the required format of collection::group::variable.')
+
+
+        # Optionally get the channel to plot
+        channel = None
+        if 'channel' in config:
+            channel = config.get('channel')
+
+        data = dataobj.get_variable_data(var_cgv[0], var_cgv[1], var_cgv[2], channel)

--- a/src/eva/diagnostics/histogram.py
+++ b/src/eva/diagnostics/histogram.py
@@ -16,14 +16,13 @@ class Histogram():
         var_cgv = varstr.split('::')
 
         if len(var_cgv) != 3:
-            logger.abort('In Histogram the variable \'var_cgv\' does not appear to '+
+            logger.abort('In Histogram the variable \'var_cgv\' does not appear to ' +
                          'be in the required format of collection::group::variable.')
-
 
         # Optionally get the channel to plot
         channel = None
         if 'channel' in config['data']:
-            channel = config.get('channel')
+            channel = config['data'].get('channel')
 
         data = dataobj.get_variable_data(var_cgv[0], var_cgv[1], var_cgv[2], channel)
 

--- a/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
@@ -234,7 +234,7 @@ diagnostics:
           - type: Histogram
             data:
               variable: experiment::ObsValueMinusGsiHofXBc::${variable}
-            channel: ${channel}
+              channel: ${channel}
             color: 'blue'
             label: 'GSI omb (all obs)'
             bins: 100
@@ -242,7 +242,7 @@ diagnostics:
           - type: Histogram
             data:
               variable: experiment::ObsValueMinusHofx::${variable}
-            channel: ${channel}
+              channel: ${channel}
             color: 'red'
             label: 'JEDI omb (all obs)'
             bins: 100

--- a/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
@@ -234,7 +234,7 @@ diagnostics:
           - type: Histogram
             data:
               variable: experiment::ObsValueMinusGsiHofXBc::${variable}
-              channel: ${channel}
+            channel: ${channel}
             color: 'blue'
             label: 'GSI omb (all obs)'
             bins: 100
@@ -242,7 +242,7 @@ diagnostics:
           - type: Histogram
             data:
               variable: experiment::ObsValueMinusHofx::${variable}
-              channel: ${channel}
+            channel: ${channel}
             color: 'red'
             label: 'JEDI omb (all obs)'
             bins: 100

--- a/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
@@ -217,6 +217,37 @@ diagnostics:
             color: 'red'
             label: 'GSI omb vs JEDI omb (passed QC in JEDI)'
 
+    # Histogram
+    - batch figure:
+        variables: *variables
+        channels: *channels
+      figure:
+        layout: [1,1]
+        title: 'JEDI omb vs. GSI omb | AMSU-A NOAA-19 | ${variable_title}'
+        output name: histograms/amsua_n19/${variable}/${channel}/gsi_omb_jedi_omb_histogram_amsua_n19_${variable}_${channel}.png
+      plots:
+        - add_xlabel: 'Observation minus h(x)'
+          add_ylabel: 'Count'
+          add_legend:
+            loc: 'upper left'
+          layers:
+          - type: Histogram
+            data:
+              variable: experiment::ObsValueMinusGsiHofXBc::${variable}
+              channel: ${channel}
+            color: 'blue'
+            label: 'GSI omb (all obs)'
+            bins: 100
+            alpha: 0.5
+          - type: Histogram
+            data:
+              variable: experiment::ObsValueMinusHofx::${variable}
+              channel: ${channel}
+            color: 'red'
+            label: 'JEDI omb (all obs)'
+            bins: 100
+            alpha: 0.5
+
     # Map plot
     # --------
 


### PR DESCRIPTION
## Description

This PR adds basic histogram support taking advantage of existing histogram declarative plotting capabilities

Here's an example of a lovely histogram with all datapoints (ignore the incorrect title saying ch 1) and one that is in the sample YAML which looks awful per channel because of a small sample size.
<img width="689" alt="Screen Shot 2022-07-26 at 1 37 31 PM" src="https://user-images.githubusercontent.com/6354668/181076670-1b11adef-fc06-4d19-b4eb-5fb9553367d9.png">

<img width="674" alt="Screen Shot 2022-07-26 at 1 50 02 PM" src="https://user-images.githubusercontent.com/6354668/181076695-5817264c-b42c-4ff7-9479-98eba9a2cf80.png">



### Issue(s) addressed

- fixes #35 

## Acceptance Criteria (Definition of Done)

Approved by @danholdaway 

## Dependencies

None

## Impact

None


@adcollard wants to look at this so tagging him so he knows how to add things to eva.