### PR TITLE
Show statistics output for multiple variables on figure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setuptools.setup(
         'cartopy>=0.18.0',
         'scikit-learn>=1.0.2',
         'xarray>=0.11.3',
+        #'seaborn>=0.12',
     ],
     package_data={
         '': [

--- a/src/eva/data/ioda_obs_space.py
+++ b/src/eva/data/ioda_obs_space.py
@@ -90,7 +90,7 @@ class IodaObsSpace(EvaBase):
 
                 # Assert that file exists
                 if not os.path.exists(filename):
-                    logger.abort(f'In IodaObsSpace file \'{filename}\' does not exist')
+                    self.logger.abort(f'In IodaObsSpace file \'{filename}\' does not exist')
 
                 # Get file header
                 ds_header = open_dataset(filename)

--- a/src/eva/plot_tools/figure.py
+++ b/src/eva/plot_tools/figure.py
@@ -404,13 +404,15 @@ class CreateFigure:
         Add annotated stats on specified ax.
         """
         # loop through the dictionary and create the sting to annotate
-        outstr = ''
-        for key, value in stats['stats'].items():
-            outstr = outstr + f'{key}: {value}    '
+        for stat_dict in stats['stats']:
 
-        ax.annotate(outstr, xy=(stats['xloc'], stats['yloc']),
-                    xycoords='axes fraction', ha=stats['ha'],
-                    **stats['kwargs'])
+            outstr = ''
+            for key, value in stat_dict['stats'].items():
+                outstr = outstr + f'{key}: {value}    '
+
+            ax.annotate(outstr, xy=(stat_dict['xloc'], stat_dict['yloc']),
+                        xycoords='axes fraction', ha=stat_dict['ha'],
+                        **stat_dict['kwargs'])
 
     def _plot_legend(self, ax, legend):
         """
@@ -631,16 +633,9 @@ class CreatePlot():
             'kwargs': kwargs
         }
 
-    def add_stats_dict(self, stats_dict={}, xloc=0.5,
-                       yloc=-0.1, ha='center', **kwargs):
+    def add_stats_dict(self, stats_dict={}):
 
-        self.stats = {
-            'stats': stats_dict,
-            'xloc': xloc,
-            'yloc': yloc,
-            'ha': ha,
-            'kwargs': kwargs
-        }
+        self.stats = stats_dict
 
     def add_legend(self, **kwargs):
 

--- a/src/eva/tests/config/testIodaObsSpaceAircraft.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceAircraft.yaml
@@ -221,17 +221,17 @@ diagnostics:
           add_legend:
             loc: 'upper left'
           statistics:
-            data:
-              variable: experiment::ObsValueMinusHofx::${variable}
-            statistic list:
-            - n
-            - min
-            - mean
-            - max
-            - std
-            - name
-            kwargs:
-              fontsize: 6
+            - data:
+                variable: experiment::ObsValueMinusHofx::${variable}
+              statistic list:
+              - n
+              - min
+              - mean
+              - max
+              - std
+              - name
+              kwargs:
+                fontsize: 6
           layers:
           - type: Histogram
             data:

--- a/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
@@ -97,18 +97,18 @@ diagnostics:
           add_legend:
             loc: 'upper left'
           statistics:
-            data:
-              variable: experiment::hofx::${variable}
-              channel: ${channel}
-            statistic list:
-            - n
-            - min
-            - mean
-            - max
-            - std
-            - name
-            kwargs:
-              fontsize: 6
+            - data:
+                variable: experiment::hofx::${variable}
+                channel: ${channel}
+              statistic list:
+              - n
+              - min
+              - mean
+              - max
+              - std
+              - name
+              kwargs:
+                fontsize: 6
           layers:
           - type: Scatter
             x:
@@ -249,18 +249,18 @@ diagnostics:
           add_legend:
             loc: 'upper left'
           statistics:
-            data:
-              variable: experiment::ObsValueMinusHofx::${variable}
-              channel: ${channel}
-            statistic list:
-            - n
-            - min
-            - mean
-            - max
-            - std
-            - name
-            kwargs:
-              fontsize: 6
+            - data:
+                variable: experiment::ObsValueMinusHofx::${variable}
+                channel: ${channel}
+              statistic list:
+              - n
+              - min
+              - mean
+              - max
+              - std
+              - name
+              kwargs:
+                fontsize: 6
           layers:
           - type: Histogram
             data:
@@ -296,18 +296,32 @@ diagnostics:
           add_legend:
             loc: 'upper left'
           statistics:
-            data:
-              variable: experiment::ObsValueMinusHofx::${variable}
-              channel: ${channel}
-            statistic list:
-            - n
-            - min
-            - mean
-            - max
-            - std
-            - name
-            kwargs:
-              fontsize: 6
+            - data:
+                variable: experiment::ObsValueMinusGsiHofXBc::${variable}
+                channel: ${channel}
+              statistic list:
+              - n
+              - min
+              - mean
+              - max
+              - std
+              - name
+              kwargs:
+                fontsize: 6
+                color: blue
+            - data:
+                variable: experiment::ObsValueMinusHofx::${variable}
+                channel: ${channel}
+              statistic list:
+              - n
+              - min
+              - mean
+              - max
+              - std
+              - name
+              kwargs:
+                fontsize: 6
+                color: red
           layers:
           - type: Density
             data:

--- a/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
@@ -292,7 +292,7 @@ diagnostics:
         output name: density/amsua_n19/${variable}/${channel}/gsi_omb_jedi_omb_density_amsua_n19_${variable}_${channel}.png
       plots:
         - add_xlabel: 'Observation minus h(x)'
-          add_ylabel: 'Count'
+          add_ylabel: 'Density'
           add_legend:
             loc: 'upper left'
           statistics:

--- a/src/eva/utilities/stats.py
+++ b/src/eva/utilities/stats.py
@@ -28,6 +28,12 @@ def stats_helper(logger, plotobj, data_collections, stats_configs):
 
     yloc = -0.1
 
+    xloc = 0.5
+    ha = 'center'
+    if len(stats_configs) > 1:
+        xloc = 0.0
+        ha = 'left'
+
     for stats_config in stats_configs:
 
         # get the variable to compute statistics for and place on the plot
@@ -76,9 +82,9 @@ def stats_helper(logger, plotobj, data_collections, stats_configs):
             logger.debug('In stats_helper, len(data) == 0')
 
         # get additional config
-        stat_dict['xloc'] = stats_config.get('xloc', 0.0)
+        stat_dict['xloc'] = stats_config.get('xloc', xloc)
         stat_dict['yloc'] = stats_config.get('yloc', yloc)
-        stat_dict['ha'] = stats_config.get('ha', 'left')
+        stat_dict['ha'] = stats_config.get('ha', ha)
         stat_dict['kwargs'] = stats_config.get('kwargs', {})
 
         # change yloc


### PR DESCRIPTION
## Description

This PR adds the option to output statistics for multiple variables on a single Figure.

## Dependencies

N/A

## Impact

Users can have multiple statisitcs output on single figure. YAML needs to be changed to provide statistics as a list. No impact to the appearance of plots if only one item in the statistics list.

New density plot produced by the testing suite:


![gsi_omb_jedi_omb_density_amsua_n19_brightness_temperature_8](https://user-images.githubusercontent.com/27729500/192529382-ebbf78a3-52c7-40ab-af7b-84348ec2eaf5.png)

