### PR TITLE
Add EMCPy as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "emcpy"]
+	path = emcpy
+	url = https://github.com/NOAA-EMC/emcpy.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "emcpy"]
-	path = emcpy
-	url = https://github.com/NOAA-EMC/emcpy.git

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(
         'cartopy>=0.18.0',
         'scikit-learn>=1.0.2',
         'xarray>=0.11.3',
-        'emcpy @ git+https://github.com/NOAA-EMC/' + 
+        'emcpy @ git+https://github.com/NOAA-EMC/' +
         'emcpy@8c1958e9ba8906a35a9677030ffa494519e11489#egg=emcpy',
     ],
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,12 @@ import setuptools
 
 setuptools.setup(
     name='eva',
-    version='1.2.2',
+    version='1.3',
     author='Community owned code',
     description='Evaluation and Verification of an Analysis',
-    url='https://github.com/danholdaway/eva',
-    package_dir={'emcpy': './emcpy/src/emcpy',
-                 '': 'src'},
-    packages=setuptools.find_packages(),
+    url='https://github.com/JCSDA-internal/eva',
+    package_dir={'': 'src'},
+    packages=setuptools.find_packages('src'),
     classifiers=[
         'Development Status :: 1 - Planning',
         'Environment :: Console',
@@ -40,6 +39,7 @@ setuptools.setup(
         'cartopy>=0.18.0',
         'scikit-learn>=1.0.2',
         'xarray>=0.11.3',
+        'emcpy @ git+https://github.com/NOAA-EMC/emcpy@8c1958e9ba8906a35a9677030ffa494519e11489#egg=emcpy',
     ],
     package_data={
         '': [

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,9 @@ setuptools.setup(
     author='Community owned code',
     description='Evaluation and Verification of an Analysis',
     url='https://github.com/danholdaway/eva',
-    package_dir={'': 'src'},
-    packages=setuptools.find_packages(where='src'),
+    package_dir={'emcpy': './emcpy/src/emcpy',
+                 '': 'src'},
+    packages=setuptools.find_packages(),
     classifiers=[
         'Development Status :: 1 - Planning',
         'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setuptools.setup(
         'cartopy>=0.18.0',
         'scikit-learn>=1.0.2',
         'xarray>=0.11.3',
-        'emcpy @ git+https://github.com/NOAA-EMC/emcpy@8c1958e9ba8906a35a9677030ffa494519e11489#egg=emcpy',
+        'emcpy @ git+https://github.com/NOAA-EMC/' + 
+        'emcpy@8c1958e9ba8906a35a9677030ffa494519e11489#egg=emcpy',
     ],
     package_data={
         '': [


### PR DESCRIPTION
## Description

PR related to Issue #57. Currently, I have added EMCPy as a submodule and updated `setup.py` so that eva will build.

`eva` imports still work, however, when trying to point to any `emcpy` modules, some issues arise. The first being issues with `__init__.py` files from `emcpy`. 

