### PR TITLE
Expand parse_channel_list to correctly handle single integer input

### DIFF
--- a/src/eva/utilities/utils.py
+++ b/src/eva/utilities/utils.py
@@ -166,11 +166,11 @@ def parse_channel_list(channels_str_or_list, logger):
                 channel_list.append(lnum)
 
         return channel_list
-    
+
     elif isinstance(channels_str_or_list, int):
 
-        # Convert int to list 
-        channel_list= [channels_str_or_list]
+        # Convert int to list
+        channel_list = [channels_str_or_list]
         return channel_list
 
     else:

--- a/src/eva/utilities/utils.py
+++ b/src/eva/utilities/utils.py
@@ -166,6 +166,12 @@ def parse_channel_list(channels_str_or_list, logger):
                 channel_list.append(lnum)
 
         return channel_list
+    
+    elif isinstance(channels_str_or_list, int):
+
+        # Convert int to list 
+        channel_list= [channels_str_or_list]
+        return channel_list
 
     else:
 


### PR DESCRIPTION

## Description
Expand the `parse_channel_list()` function in `src/utility/utils.py` to correctly handle the input and conversion of single integers to list.

When parsing a yaml file's channel list the type of the result may be a string if more than one channel is requested, or a single integer if only one channel is requested.  The single integer case was not implemented and results in an abort.  This change handles the single integer case, returning the value in a list.

To test, modify the config/testGsiObsSpaceAmsuaMetop-A.yaml changing 
`channels: &channels 3,8` to `channels: &channels 8`.  With this change the histogram for channel 8 is correctly produced, whereas without this change the result was an abort.

## Dependencies
None

## Impact
None
