### PR TITLE
Fix Location coordinate values to make compatible with Skylab

### DIFF
--- a/src/eva/data/ioda_obs_space.py
+++ b/src/eva/data/ioda_obs_space.py
@@ -43,16 +43,6 @@ def subset_channels(ds, channels, add_channels_variable=False):
 # --------------------------------------------------------------------------------------------------
 
 
-def check_location(location):
-    if max(location) == 0:
-        new_location = range(location.size)
-        location = new_location + location
-    return location
-
-
-# --------------------------------------------------------------------------------------------------
-
-
 class IodaObsSpace(EvaBase):
 
     # ----------------------------------------------------------------------------------------------
@@ -86,6 +76,7 @@ class IodaObsSpace(EvaBase):
 
             # Loop over filenames
             # -------------------
+            total_loc = 0
             for filename in filenames:
 
                 # Assert that file exists
@@ -95,8 +86,10 @@ class IodaObsSpace(EvaBase):
                 # Get file header
                 ds_header = open_dataset(filename)
 
-                # fix location if they are all zeros
-                ds_header['Location'] = check_location(ds_header['Location'])
+                # Fix location in case ioda did not set it
+                locations_this_file = range(total_loc, total_loc + ds_header['Location'].size)
+                ds_header = ds_header.assign_coords({"Location": locations_this_file})
+                total_loc = total_loc + ds_header['Location'].size
 
                 # Read header part of the file to get coordinates
                 ds_groups = Dataset()


### PR DESCRIPTION
## Description

When skylab merges ioda files the Location coordinate in the file ends up with something a bit unusual. Only the values from the first file are present and the rest are zero. This is mightily confusing for xarray and bypasses the logic we had in eva for checking if Location coordinate is set properly, because it was assuming zeros everywhere if not set. 

This code fixes that by forcing the Location coordinate to index values. In testing the Eva code with the very large (1.4million obs) ABI GOES-16 file we also noticed the read part was very slow. This fix also eliminates this slowness.

The attached plot of 1,440,392 observations is created in around 21 seconds (instead of minutes before) with the read step taking only 2.15 seconds.

![observations_abi_g16_brightnessTemperature_8](https://user-images.githubusercontent.com/27729500/221684884-bb84b67c-5608-4395-9d21-794b04efbeeb.png)

Yaml file: 

``` YAML
diagnostics:

  # Data read
  # ---------
- data:
    type: IodaObsSpace
    datasets:
      - name: experiment
        missing_value_threshold: 400.0
        filenames:
          - fb.abi_g16_bt_8km.2022-02-15T00:00:00Z_0000.nc4
        channels: &channels 8
        groups:
          - name: ObsValue
            variables: &variables [brightnessTemperature]
          - name: hofx
          - name: EffectiveQC
          - name: MetaData

  graphics:

    # Map plots
    # ---------

    # Observations
    - batch figure:
        variables: *variables
        channels: *channels
      dynamic options:
        - type: vminvmaxcmap
          channel: ${channel}
          data variable: experiment::ObsValue::${variable}
      figure:
        figure size: [20,10]
        layout: [1,1]
        title: 'Observations | ABI GOES 16 | Obs Value'
        output name: map_plots/abi_g16/${variable}/${channel}/observations_abi_g16_${variable}_${channel}.png
      plots:
        - mapping:
            projection: plcarr
            domain: global
          add_map_features: ['coastline']
          add_colorbar:
            label: ObsValue
          add_grid:
          layers:
          - type: MapScatter
            longitude:
              variable: experiment::MetaData::longitude
            latitude:
              variable: experiment::MetaData::latitude
            data:
              variable: experiment::ObsValue::${variable}
              channel: ${channel}
            markersize: 2
            label: ObsValue
            colorbar: true
            cmap: ${dynamic_cmap}
            vmin: ${dynamic_vmin}
            vmax: ${dynamic_vmax}
```

## Dependencies

N/A

## Impact

N/A
