### PR TITLE
Fix indent to allow multiple GSI diag files to be read in

### DIFF
--- a/src/eva/data/gsi_obs_space.py
+++ b/src/eva/data/gsi_obs_space.py
@@ -234,8 +234,8 @@ class GsiObsSpace(EvaBase):
                                           group_name + '\' in file ' + filename +
                                           ' does not have any variables.')
 
-            # Add the dataset to the collections
-            data_collections.create_or_add_to_collection(collection_name, ds, 'nobs')
+                # Add the dataset to the collections
+                data_collections.create_or_add_to_collection(collection_name, ds, 'nobs')
 
         # Nan out unphysical values
         data_collections.nan_float_values_outside_threshold(threshold)


### PR DESCRIPTION
The indent of the 
```
data_collections.create_or_add_to_collection(collection_name, ds, 'nobs')
```
line in `src/eva/data/gsi_obs_space.py` means that only one file (the last one listed) is read in.

This PR fixes the indent.

References issue [#75](https://github.com/JCSDA-internal/eva/issues/75)