### PR TITLE
Fix for all NAN data in map scatter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name='eva',
-    version='1.3.3',
+    version='1.3.4',
     author='Community owned code',
     description='Evaluation and Verification of an Analysis',
     url='https://github.com/JCSDA-internal/eva',

--- a/src/eva/diagnostics/map_scatter.py
+++ b/src/eva/diagnostics/map_scatter.py
@@ -2,6 +2,7 @@ from eva.eva_path import return_eva_path
 from eva.utilities.utils import get_schema, update_object, slice_var_from_str
 import emcpy.plots.map_plots
 import os
+import numpy as np
 
 
 class MapScatter():
@@ -25,6 +26,11 @@ class MapScatter():
         lonvar = lonvar.flatten()
         latvar = latvar.flatten()
         datavar = datavar.flatten()
+
+        # If everything is nan plotting will fail so just plot some large values
+        if np.isnan(datavar).all():
+            datavar[np.isnan(datavar)] = 1.0e38
+
         # create declarative plotting MapScatter object
         self.plotobj = emcpy.plots.map_plots.MapScatter(latvar, lonvar, datavar)
         # get defaults from schema

--- a/src/eva/plot_tools/dynamic_config.py
+++ b/src/eva/plot_tools/dynamic_config.py
@@ -54,8 +54,14 @@ def vminvmaxcmap(logger, option_dict, plots_dict, data_collections):
 
     # Find minimum and maximum values
     cmap = option_dict.get('sequential colormap', 'viridis')
-    vmax = np.nanmax(datavar_check)
-    vmin = np.nanmin(datavar_check)
+
+    # If everything is nan plot some large min/max (plotting code should do the same)
+    if np.isnan(datavar_check).all():
+        vmax = 1.0e38
+        vmin = 1.0e38
+    else:
+        vmax = np.nanmax(datavar_check)
+        vmin = np.nanmin(datavar_check)
 
     # If positive and negative values are present then a diverging colormap centered on zero should
     # be used.

--- a/src/eva/transforms/transform_utils.py
+++ b/src/eva/transforms/transform_utils.py
@@ -47,11 +47,11 @@ def replace_cgv(logger, collection, group, variable, *argv):
 
     # Create dictionary with templates
     tmplt_dict = {}
-    if collection is not 'none':
+    if collection != 'none':
         tmplt_dict['collection'] = collection
-    if group is not 'none':
+    if group != 'none':
         tmplt_dict['group'] = group
-    if variable is not 'none':
+    if variable != 'none':
         tmplt_dict['variable'] = variable
 
     # Perform replace for the argument list


### PR DESCRIPTION
## Description

An error started occurring when we switched to Skylab 3 modules. The problem is that when the data is nan the map scatter plotting would fail (undignified crash). Previously is just made plots of nothing. I suspect this is an underlying version change in Matplotlib. This change is to makes plots of 1e38 instead of nothing. Colorbars are also changed and some other changes to avoid warnings.

## Dependencies

N/A
