### PR TITLE
Add select_time transform

### DIFF
--- a/src/eva/data/mon_data_space.py
+++ b/src/eva/data/mon_data_space.py
@@ -83,36 +83,37 @@ class MonDataSpace(EvaBase):
             for filename in filenames:
 
                 # read data file
-                count_tmp, penalty_tmp, omgnbc_sum_tmp, total_sum_tmp, \
-                    omgbc_sum_tmp, omgnbc_sum2_tmp, total_sum2_tmp, omgbc_sum2_tmp, cycle_tm = \
+                count_tmp, penalty_tmp, omgnbc_sum_tmp, total_sum_tmp,\
+                    omgbc_sum_tmp, omgnbc_sum2_tmp, total_sum2_tmp, omgbc_sum2_tmp, cycle_tm =\
                     self.read_radmon_ieee(filename, nchans, nregion)
 
                 # add cycle as a variable in dataset
-                cycle_tmp = [[cycle_tm] * nregion] * nchans
+                add_cycle = cycle_tm.strftime("%Y%m%d%H")
+                cycle_tmp = [[add_cycle] * nregion] * nchans
 
                 # create dataset from file contents
                 timestep_ds = Dataset(
                     {
-                        "count": (("channels", "regions"), count_tmp),
-                        "penalty": (("channels", "regions"), penalty_tmp),
-                        "omgnbc": (("channels", "regions"), omgnbc_sum_tmp),
-                        "total": (("channels", "regions"), total_sum_tmp),
-                        "omgbc": (("channels", "regions"), omgbc_sum_tmp),
-                        "omgnbc2": (("channels", "regions"), omgnbc_sum2_tmp),
-                        "total2": (("channels", "regions"), total_sum2_tmp),
-                        "omgbc2": (("channels", "regions"), omgbc_sum2_tmp),
-                        "cycle": (("channels", "regions"), cycle_tmp),
+                        "count": (("Channel", "Region"), count_tmp),
+                        "penalty": (("Channel", "Region"), penalty_tmp),
+                        "omgnbc": (("Channel", "Region"), omgnbc_sum_tmp),
+                        "total": (("Channel", "Region"), total_sum_tmp),
+                        "omgbc": (("Channel", "Region"), omgbc_sum_tmp),
+                        "omgnbc2": (("Channel", "Region"), omgnbc_sum2_tmp),
+                        "total2": (("Channel", "Region"), total_sum2_tmp),
+                        "omgbc2": (("Channel", "Region"), omgbc_sum2_tmp),
+                        "cycle": (("Channel", "Region"), cycle_tmp),
                     },
-                    coords={"channels": channo, "regions": np.arange(1, nregion+1)},
+                    coords={"Channel": channo, "Region": np.arange(1, nregion+1)},
                     attrs={'satellite': satellite, 'sensor': sensor},
                 )
-                timestep_ds['times'] = cycle_tm
+                timestep_ds['Time'] = cycle_tm.strftime("%Y%m%d%H")
 
                 # Add this dataset to the list of ds_list
                 ds_list.append(timestep_ds)
 
             # Concatenate datasets from ds_list into a single dataset
-            ds = concat(ds_list, dim='times')
+            ds = concat(ds_list, dim='Time')
 
             # Group name and variables
             # ------------------------
@@ -123,12 +124,12 @@ class MonDataSpace(EvaBase):
                 # Drop channels not in user requested list
                 # ----------------------------------------
                 if drop_channels:
-                    ds = self.subset_coordinate(ds, 'channels', requested_channels)
+                    ds = self.subset_coordinate(ds, 'Channel', requested_channels)
 
                 # Drop regions not in user requested list
                 # ---------------------------------------
                 if drop_regions:
-                    ds = self.subset_coordinate(ds, 'regions', requested_regions)
+                    ds = self.subset_coordinate(ds, 'Region', requested_regions)
 
                 # If user specifies all variables set to group list
                 # -------------------------------------------------
@@ -139,6 +140,13 @@ class MonDataSpace(EvaBase):
                 # ---------------------------------------------------
                 vars_to_remove = list(set(list(ds.keys())) - set(group_vars))
                 ds = ds.drop_vars(vars_to_remove)
+
+                # Conditionally add channel as a variable using single dimension
+                if 'channel' in group_vars:
+                    chan_tmp = np.zeros([nchans])
+                    for x in range(nchans):
+                        chan_tmp[x] = channo[x]
+                    ds['channel'] = (['Channel'], chan_tmp)
 
                 # Rename variables with group
                 rename_dict = {}

--- a/src/eva/tests/config/testMonSummary.yaml
+++ b/src/eva/tests/config/testMonSummary.yaml
@@ -1,0 +1,150 @@
+# Test Monitor Summary plot performs the following:
+#   1.  Load binary monitor data for 5 cycles
+#   2.  Select obs counts from last 4 cycles
+#   3.  Select total bias correction for 1 cycle and average of last 4
+#   4.  Plot obs counts for the 4 cycles (panel 1).
+#   5.  Plot bias correction for 1 cycle and average of 4 (panel 2).
+
+diagnostics:
+
+  # Data read
+  # ---------
+- data:
+    type: MonDataSpace
+    datasets:
+      - name: experiment
+        satellite: metop-a
+        sensor: hirs4
+        control_file:
+          - ${data_input_path}/time.hirs4_metop-a.ctl
+        filenames:
+          - ${data_input_path}/time.hirs4_metop-a.2015051418.ieee_d
+          - ${data_input_path}/time.hirs4_metop-a.2015051500.ieee_d
+          - ${data_input_path}/time.hirs4_metop-a.2015051506.ieee_d
+          - ${data_input_path}/time.hirs4_metop-a.2015051512.ieee_d
+          - ${data_input_path}/time.hirs4_metop-a.2015051518.ieee_d
+
+        channels: &channels 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19
+        regions: &regions 1
+        groups:
+          - name: GsiIeee
+            variables: ['count', 'cycle', 'total', 'channel']
+
+  transforms:
+    - transform: select time
+      new name: experiment::GsiIeee::count1
+      starting field: experiment::GsiIeee::count
+      cycles: 2015051418
+      for:
+        variable: [none]
+
+    - transform: select time
+      new name: experiment::GsiIeee::count2
+      starting field: experiment::GsiIeee::count
+      cycles: 2015051500
+      for:
+        variable: [none]
+
+    - transform: select time
+      new name: experiment::GsiIeee::count3
+      starting field: experiment::GsiIeee::count
+      cycles: 2015051506
+      for:
+        variable: [none]
+
+    - transform: select time
+      new name: experiment::GsiIeee::count4
+      starting field: experiment::GsiIeee::count
+      cycles: 2015051512
+      for:
+        variable: [none]
+
+    # Note that total is the total bias correction for a given
+    # channel/region.  To find the average divide total by count.
+    - transform: arithmetic
+      new name: experiment::GsiIeee::total_avg
+      equals: experiment::GsiIeee::total/experiment::GsiIeee::count
+      for:
+        variable: [none]
+
+    # Single cycle total bias correction
+    - transform: select time
+      new name: experiment::GsiIeee::total_1cyc
+      starting field: experiment::GsiIeee::total_avg
+      cycles: 2015051512
+      for:
+        variable: [none]
+
+     # 4 cycle total bias correction using time slice
+    - transform: select time
+      new name: experiment::GsiIeee::total_4cyc
+      starting field: experiment::GsiIeee::total_avg
+      cycles: [2015051418, 2015051512]
+      for:
+        variable: [none]
+
+
+  graphics:
+    # Summary plots
+    # ---------------
+      - figure:
+          layout: [2,1]
+          figure size: [12,10]
+          title: 'hirs4_metop-a | Number of Obs Count'
+          output name: lineplots/hirs4_metop-a/summary.hirs4_metop-a.png
+
+        plots:
+          - add_xlabel: 'Channel'
+            add_ylabel: 'Observation Count'
+            add_legend:
+              loc: 'upper right'
+            layers:
+            - type: LinePlot
+              x:
+                variable: experiment::GsiIeee::channel
+              y:
+                variable: experiment::GsiIeee::count1
+              color: 'blue'
+              label: '2015051418'
+            - type: LinePlot
+              x:
+                variable: experiment::GsiIeee::channel
+              y:
+                variable: experiment::GsiIeee::count2
+              color: 'green'
+              label: '2015051500'
+            - type: LinePlot
+              x:
+                variable: experiment::GsiIeee::channel
+              y:
+                variable: experiment::GsiIeee::count3
+              color: 'yellow'
+              label: '2015051506'
+            - type: LinePlot
+              x:
+                variable: experiment::GsiIeee::channel
+              y:
+                variable: experiment::GsiIeee::count4
+              color: 'red'
+              label: '2015051512'
+
+          - add_xlabel: 'Channel'
+            add_ylabel: 'Total Bias Correction (K)'
+            add_legend:
+              loc: 'upper right'
+            layers:
+            - type: LinePlot
+              x:
+                variable: experiment::GsiIeee::channel
+              y:
+                variable: experiment::GsiIeee::total_1cyc
+              color: 'blue'
+              label: '2015051512'
+
+            - type: LinePlot
+              x:
+                variable: experiment::GsiIeee::channel
+              y:
+                variable: experiment::GsiIeee::total_4cyc
+              color: 'red'
+              label: 'Avg last 4 cycles'

--- a/src/eva/transforms/select_time.py
+++ b/src/eva/transforms/select_time.py
@@ -1,0 +1,90 @@
+# (C) Copyright 2021-2022 NOAA/NWS/EMC
+#
+# (C) Copyright 2021-2022 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+from eva.transforms.transform_utils import parse_for_dict, split_collectiongroupvariable
+from eva.transforms.transform_utils import replace_cgv
+from eva.utilities.config import get
+from eva.utilities.logger import Logger
+
+
+# --------------------------------------------------------------------------------------------------
+#  Select a variable by the Time dimension in form YYYYMMDDHH.  If the input is a single time
+#  then values for the specified variable will be selected for that cycle and added to
+#  data_collections.
+#
+#  If two cycle times are included they will be used as the bounds for a time slice, and the
+#  average of that span will be added to the data_collections.  Note that when specifying a slice
+#  the order must be older (lower) to newer (higher).
+
+def select_time(config, data_collections):
+
+    # Create a logger
+    logger = Logger('SelectTimeTransform')
+
+    # Parse config for dictionary
+    [collections, groups, variables] = parse_for_dict(config, logger)
+
+    # Parse config for the expression and new collection/group/variable naming
+    new_name_template = get(config, logger, 'new name')
+    starting_field_template = get(config, logger, 'starting field')
+
+    # Get cycles from yaml file and confirm there are 1 or 2 times
+    cyc = get(config, logger, 'cycles')
+    if type(cyc) is list:
+        cycles = cyc
+    else:
+        cycles = [cyc]
+
+    if None in cycles:
+        logger.abort('cycles: for transformation not specified in yaml file. ' +
+                     'This should be cycles: followed by 1 or 2 cycle times ' +
+                     'in YYYYMMDDHH format.')
+    if len(cycles) > 2:
+        logger.info('WARNING:  more than 2 cycles specified in yaml file. ' +
+                    'Only the first 2 times will be used.')
+
+    # Loop over the templates
+    for collection in collections:
+
+        for group in groups:
+
+            for variable in variables:
+
+                if variable is not None:
+                    # Replace collection, group, variable in template
+                    [new_name, starting_field] = replace_cgv(logger, collection, group, variable,
+                                                             new_name_template,
+                                                             starting_field_template)
+                else:
+                    new_name = new_name_template
+                    starting_field = starting_field_template
+
+                # Get a dataset for the requested collection::group::variable
+                cgv = split_collectiongroupvariable(logger, starting_field)
+                select_time = data_collections.get_variable_data_array(cgv[0], cgv[1], cgv[2])
+
+                # Get the collection, group, var for new dataset
+                cgv_new = split_collectiongroupvariable(logger, new_name)
+
+                # If 2 times, return the mean of a Time slice, else select single Time
+                if len(cycles) >= 2:
+                    select_time = select_time.sel(Time=slice(str(cycles[0]), str(cycles[1])))
+                    select_time = select_time.mean(dim='Time')
+                else:
+                    select_time = select_time.sel(Time=str(cycles[0]))
+
+                data_collections.add_variable_to_collection(cgv_new[0], cgv_new[1],
+                                                            cgv_new[2], select_time)
+
+    data_collections.display_collections()
+
+# --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds a `select_time` data transform.  This provides means to select a subset of a variable by individual cycle or by time slice.  The selected subset is added to the data_collections as directed by the transform.

Additionally some changes have been made to `data/mon_data_space.py` to standardize it with respect to the other data loading files and common xarray standards.  The new `config/testMonSummary.yaml` file uses the `select_time` transform to manipulate data and then generate images similar to RadMon summary plots including plots of mean values for specific multi-cycle periods.

## Dependencies
None.

## Impact
None.

Ref #76 