### PR TITLE
Fix if there is no field data in stats.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name='eva',
-    version='1.3.4',
+    version='1.3.5',
     author='Community owned code',
     description='Evaluation and Verification of an Analysis',
     url='https://github.com/JCSDA-internal/eva',

--- a/src/eva/utilities/stats.py
+++ b/src/eva/utilities/stats.py
@@ -99,6 +99,10 @@ def stats_helper(logger, plot_obj, data_collections, config):
         # Get field data
         field_data = get_field_data(logger, field, data_collections)
 
+        # Stats will fail if the field_data list is empty
+        if not field_data.any():
+            field_data = [1.0e38, 1.0e38, 1.0e38]
+
         # Initialize the stats string
         stats_string = ''
 


### PR DESCRIPTION
Due to filtering (EffectiveQC or others) some obs sources may contain no data which leads to Eva failing while calculating stats. This quick fix circumvents that by assigning large values for stat calculations.