### PR TITLE
Bugfix/channel fix

### DIFF
--- a/src/eva/data/data_collections.py
+++ b/src/eva/data/data_collections.py
@@ -92,6 +92,15 @@ class DataCollections:
 
     # ----------------------------------------------------------------------------------------------
 
+    def adjust_location_dimension_name(self, location_dimension_name):
+
+        for collection in self._collections.keys():
+            if location_dimension_name in list(self._collections[collection].dims):
+                self._collections[collection] = \
+                    self._collections[collection].rename_dims({location_dimension_name: 'Location'})
+
+    # ----------------------------------------------------------------------------------------------
+
     def add_variable_to_collection(self, collection_name, group_name, variable_name, variable):
 
         # Assert that new variable is an xarray Dataarray

--- a/src/eva/data/ioda_obs_space.py
+++ b/src/eva/data/ioda_obs_space.py
@@ -36,7 +36,7 @@ def subset_channels(ds, channels, add_channels_variable=False):
 
         # Keep needed channels and reset dimension in Dataset
         if channel_use < channel_in_file:
-            ds = ds.sel(channel=channels)
+            ds = ds.sel(Channel=channels)
 
     return ds
 
@@ -99,10 +99,10 @@ class IodaObsSpace(EvaBase):
                 ds_groups = Dataset()
 
                 # Save sensor_channels for later
-                channel_present = False
+                add_channels = False
                 if 'Channel' in ds_header.keys():
                     sensor_channels = ds_header['Channel']
-                    channel_present = True
+                    add_channels = True
 
                 # Merge in the header and close
                 ds_groups = ds_groups.merge(ds_header)
@@ -160,9 +160,14 @@ class IodaObsSpace(EvaBase):
                         rename_dict[group_var] = group_name + '::' + group_var
                     ds = ds.rename(rename_dict)
 
-                    # Reset channel numbers from header
-                    if channel_present and group_name == 'MetaData':
-                        ds[group_name + '::' + 'channelNumber'] = sensor_channels
+                    # Reset channel numbers from header and copy channel numbers
+                    # into MetaData for easier use
+                    if add_channels:
+                        ds['Channel'] = sensor_channels
+                        # Explicitly add the channels to the collection (we do not want to
+                        # include this in the 'variables' list in the YAML to avoid transforms
+                        # being applied to them)
+                        ds['MetaData::channelNumber'] = sensor_channels
 
                     # Set channels
                     ds = subset_channels(ds, channels)

--- a/src/eva/data/ioda_obs_space.py
+++ b/src/eva/data/ioda_obs_space.py
@@ -22,13 +22,13 @@ import netCDF4 as nc
 
 def subset_channels(ds, channels, add_channels_variable=False):
 
-    if 'channel' in list(ds.dims):
+    if 'Channel' in list(ds.dims):
 
         # Number of user requested channels
         channel_use = len(channels)
 
         # Number of channels in the file
-        channel_in_file = ds.channel.size
+        channel_in_file = ds.Channel.size
 
         # If user provided no channels then use all channels
         if channel_use == 0:
@@ -91,13 +91,17 @@ class IodaObsSpace(EvaBase):
                 ds_header = ds_header.assign_coords({"Location": locations_this_file})
                 total_loc = total_loc + ds_header['Location'].size
 
+                if 'Cluster' in ds_header.keys():
+                    clusters_this_file = range(0, ds_header['Cluster'].size)
+                    ds_header = ds_header.assign_coords({"Cluster": clusters_this_file})
+
                 # Read header part of the file to get coordinates
                 ds_groups = Dataset()
 
                 # Save sensor_channels for later
                 channel_present = False
-                if 'channel' in ds_header.keys():
-                    sensor_channels = ds_header['channel']
+                if 'Channel' in ds_header.keys():
+                    sensor_channels = ds_header['Channel']
                     channel_present = True
 
                 # Merge in the header and close
@@ -157,8 +161,8 @@ class IodaObsSpace(EvaBase):
                     ds = ds.rename(rename_dict)
 
                     # Reset channel numbers from header
-                    if channel_present:
-                        ds['channel'] = sensor_channels
+                    if channel_present and group_name == 'MetaData':
+                        ds[group_name + '::' + 'channelNumber'] = sensor_channels
 
                     # Set channels
                     ds = subset_channels(ds, channels)

--- a/src/eva/diagnostics/scatter.py
+++ b/src/eva/diagnostics/scatter.py
@@ -31,6 +31,7 @@ class Scatter():
             channel = config.get('channel')
 
         xdata = dataobj.get_variable_data(var0_cgv[0], var0_cgv[1], var0_cgv[2], channel)
+        xdata1 = dataobj.get_variable_data(var0_cgv[0], var0_cgv[1], var0_cgv[2])
         ydata = dataobj.get_variable_data(var1_cgv[0], var1_cgv[1], var1_cgv[2], channel)
 
         # see if we need to slice data

--- a/src/eva/tests/config/testGsiObsSpaceAmsuaMetop-A.yaml
+++ b/src/eva/tests/config/testGsiObsSpaceAmsuaMetop-A.yaml
@@ -13,11 +13,20 @@ diagnostics:
         channels: &channels 3,8
         groups:
           - name: GsiNcDiag
+            # Note: channelNumber is automatically added to the output and should not
+            # be listed as a variable
             variables: &variables [Obs_Minus_Forecast_adjusted,
                                    Observation,
                                    Latitude,
                                    Longitude]
 
+  transforms:
+    # Stats for hofxPassedGSIQc
+    - transform: channel_stats
+      variable_name: experiment::GsiNcDiag::${variable}
+      for:
+        variable: *variables  
+  
   graphics:
     # Histogram plots
     # ---------------
@@ -60,3 +69,28 @@ diagnostics:
             label: 'GSI omb (all obs)'
             bins: 100
             alpha: 0.5
+
+    # ---------- Statistical Plot ----------
+    # JEDI h(x) vs GSI h(x)
+    # -------------------------
+    - figure:
+        layout: [1,1]
+        title: 'Mean HofX vs Channel'
+        output name: hofx_vs_channel/amsua_n19/brightness_temperature/meanhofx_vs_channel.png
+      plots:
+        - add_xlabel: 'Channel'
+          add_ylabel: 'GSI HofX'
+          add_grid:
+          add_legend:
+            loc: 'upper left'
+          layers:
+          - type: Scatter
+            x:
+              variable: experiment::GsiNcDiag::channelNumber
+            y:
+              variable: experiment::GsiNcDiagMean::Obs_Minus_Forecast_adjusted
+            markersize: 5
+            color: 'red'
+            label: 'GSI h(x) versus channels (all obs)'
+            do_linear_regression: False
+

--- a/src/eva/tests/config/testGsiObsSpaceAmsuaMetop-A.yaml
+++ b/src/eva/tests/config/testGsiObsSpaceAmsuaMetop-A.yaml
@@ -25,8 +25,8 @@ diagnostics:
     - transform: channel_stats
       variable_name: experiment::GsiNcDiag::${variable}
       for:
-        variable: *variables  
-  
+        variable: *variables
+
   graphics:
     # Histogram plots
     # ---------------

--- a/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
@@ -10,7 +10,7 @@ diagnostics:
           - ${data_input_path}/ioda_obs_space.amsua_n19.hofx.2020-12-14T210000Z.nc4
         channels: &channels 3,8
         # Note: channelNumber is automatically added to the output and should not
-        # be listed below 
+        # be listed below
         groups:
           - name: ObsValue
             variables: &variables [brightnessTemperature]

--- a/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceAmsuaN19.yaml
@@ -9,6 +9,8 @@ diagnostics:
         filenames:
           - ${data_input_path}/ioda_obs_space.amsua_n19.hofx.2020-12-14T210000Z.nc4
         channels: &channels 3,8
+        # Note: channelNumber is automatically added to the output and should not
+        # be listed below 
         groups:
           - name: ObsValue
             variables: &variables [brightnessTemperature]

--- a/src/eva/tests/config/testIodaObsSpaceIASI_Metop-A.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceIASI_Metop-A.yaml
@@ -17,14 +17,13 @@ diagnostics:
                    416, 418, 423, 426, 428, 432, 433, 434, 439, 442, 445, 450, 457, 459, 472, 477, 483,
                    509, 515, 546, 552, 559, 566, 571, 573, 578, 584, 594, 625, 646, 662, 668, 705, 739,
                    756, 797, 867, 906, 921, 1027, 1046, 1090, 1098, 1121, 1133, 1173]
+        # Note: channelNumber is automatically added to the output and should not be listed below         
         groups:
           - name: ObsValue
             variables: &variables ['brightnessTemperature']
           - name: GsiHofXBc
           - name: hofx
           - name: EffectiveQC
-          - name: MetaData
-            variables: ['sensorChannelNumber']
           - name: GsiEffectiveQC
           - name: GsiFinalObsError
           - name: EffectiveError
@@ -71,7 +70,7 @@ diagnostics:
           layers:
           - type: Scatter
             x:
-              variable: experiment::MetaData::sensorChannelNumber
+              variable: experiment::MetaData::channelNumber
             y:
               variable: experiment::hofxMean::brightnessTemperature
             markersize: 5
@@ -80,7 +79,7 @@ diagnostics:
             do_linear_regression: False
           - type: Scatter
             x:
-              variable: experiment::MetaData::sensorChannelNumber
+              variable: experiment::MetaData::channelNumber
             y:
               variable: experiment::hofxPassedGSIQcMean::brightnessTemperature
             markersize: 5

--- a/src/eva/tests/config/testIodaObsSpaceIASI_Metop-A.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceIASI_Metop-A.yaml
@@ -17,7 +17,7 @@ diagnostics:
                    416, 418, 423, 426, 428, 432, 433, 434, 439, 442, 445, 450, 457, 459, 472, 477, 483,
                    509, 515, 546, 552, 559, 566, 571, 573, 578, 584, 594, 625, 646, 662, 668, 705, 739,
                    756, 797, 867, 906, 921, 1027, 1046, 1090, 1098, 1121, 1133, 1173]
-        # Note: channelNumber is automatically added to the output and should not be listed below         
+        # Note: channelNumber is automatically added to the output and should not be listed below
         groups:
           - name: ObsValue
             variables: &variables ['brightnessTemperature']

--- a/src/eva/transforms/channel_stats.py
+++ b/src/eva/transforms/channel_stats.py
@@ -50,6 +50,8 @@ def channel_stats(config, data_collections):
         for group in groups:
             for variable in variables:
 
+                if variable == 'Latitude' or variable == 'Longitude':
+                    continue
                 # Replace collection, group, variable in template
                 [variable_name] = replace_cgv(logger, collection, group, variable,
                                               variable_name_template)


### PR DESCRIPTION
Two issues were found when trying to plot channel stats for IASI when the input data to UFO came from the IODA converters or from GSI diag files.

1) The 'Cluster' dimension comprises all zeros and was causing the code to crash.  This is solved by forcing 'Cluster' to have definite values: [1,2,3,4,5,6,7]
2) Problems with inconsistencies between the channel array dimensions and the arrays that are output from channel_stats.  The supposedly 1D channel arrays kept being replicated along the `Locations` dimension by the `transform` functions and were this inconsistent with the 1D stats arrays.  This is solved by explicitly adding a `channelNumber` array in the data collection, but not specifying in the `variables` section of the YAML, so it does not get processing in the transforms.

There were another of other bug fixes and tidy-ups.
