### PR TITLE
Run workflows after merge as well as in PR

### DIFF
--- a/.github/workflows/eva_tests_application.yml
+++ b/.github/workflows/eva_tests_application.yml
@@ -1,9 +1,14 @@
 name: Eva Application Tests
 
 on:
+  push:
+    branches:
+      - develop
   pull_request:
-    types: [opened, synchronize, reopened]
-
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   evaapp:

--- a/.github/workflows/eva_tests_notebook.yml
+++ b/.github/workflows/eva_tests_notebook.yml
@@ -1,9 +1,14 @@
 name: Eva Notebook Tests
 
 on:
+  push:
+    branches:
+      - develop
   pull_request:
-    types: [opened, synchronize, reopened]
-
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   evaapp:

--- a/.github/workflows/python_coding_norms.yml
+++ b/.github/workflows/python_coding_norms.yml
@@ -1,8 +1,14 @@
 name: Python Coding Norms
 
 on:
+  push:
+    branches:
+      - develop
   pull_request:
-    types: [opened, synchronize, reopened]
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   pycodestyle:

--- a/.github/workflows/yaml_coding_norms.yml
+++ b/.github/workflows/yaml_coding_norms.yml
@@ -1,8 +1,14 @@
 name: YAML Coding Norms
 
 on:
+  push:
+    branches:
+      - develop
   pull_request:
-      types: [opened, synchronize, reopened]
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 # This validation is equivalent to running on the command line:
 #   yamllint -d relaxed --no-warnings

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
   
 # Evaluation and Verification of the Analysis (EVA)
 
-[![Eva Application Tests](https://github.com/JCSDA-internal/eva/actions/workflows/eva_tests_application.yml/badge.svg)](https://github.com/JCSDA-internal/eva/actions/workflows/eva_tests_application.yml)
-[![Eva Notebook Tests](https://github.com/JCSDA-internal/eva/actions/workflows/eva_tests_notebook.yml/badge.svg)](https://github.com/JCSDA-internal/eva/actions/workflows/eva_tests_notebook.yml)
-[![Python Coding Norms](https://github.com/JCSDA-internal/eva/actions/workflows/python_coding_norms.yml/badge.svg)](https://github.com/JCSDA-internal/eva/actions/workflows/python_coding_norms.yml)
-[![YAML Coding Norms](https://github.com/JCSDA-internal/eva/actions/workflows/yaml_coding_norms.yml/badge.svg)](https://github.com/JCSDA-internal/eva/actions/workflows/yaml_coding_norms.yml)
+[![Eva Application Tests](https://github.com/JCSDA-internal/eva/actions/workflows/eva_tests_application.yml/badge.svg?branch=develop)](https://github.com/JCSDA-internal/eva/actions/workflows/eva_tests_application.yml)
+[![Eva Notebook Tests](https://github.com/JCSDA-internal/eva/actions/workflows/eva_tests_notebook.yml/badge.svg?branch=develop)](https://github.com/JCSDA-internal/eva/actions/workflows/eva_tests_notebook.yml)
+[![Python Coding Norms](https://github.com/JCSDA-internal/eva/actions/workflows/python_coding_norms.yml/badge.svg?branch=develop)](https://github.com/JCSDA-internal/eva/actions/workflows/python_coding_norms.yml)
+[![YAML Coding Norms](https://github.com/JCSDA-internal/eva/actions/workflows/yaml_coding_norms.yml/badge.svg?branch=develop)](https://github.com/JCSDA-internal/eva/actions/workflows/yaml_coding_norms.yml)
 
 </div>
 


### PR DESCRIPTION
## Description

Currently the status badges on the repos reflect the status across all PRs rather than the status of the develop branch. There is no status for develop because the actions are not run for develop. This PR makes all workflows run on develop after merging PRs and updates the badges to reflect the status only of develop.