### PR TITLE
eva_driver fix

### DIFF
--- a/src/eva/eva_driver.py
+++ b/src/eva/eva_driver.py
@@ -13,6 +13,8 @@ from eva.transforms.transform_driver import transform_driver
 from eva.plot_tools.figure_driver import figure_driver
 from eva.data.data_collections import DataCollections
 from eva.utilities.utils import load_yaml_file
+import argparse
+import os
 
 
 def eva(eva_config, eva_logger=None):


### PR DESCRIPTION
I wasn't able to execute `eva` from the CLI without the missing modules: `argparse`, `os`