### PR TITLE
Extend mon_data_space.py to support channel markers

### DIFF
--- a/src/eva/data/mon_data_space.py
+++ b/src/eva/data/mon_data_space.py
@@ -120,23 +120,26 @@ class MonDataSpace(EvaBase):
             if group_vars == 'all':
                 group_vars = list(ds.data_vars)
 
-            # Drop data variables not in user requested variables
-            # ---------------------------------------------------
-            vars_to_remove = list(set(list(ds.keys())) - set(group_vars))
-            ds = ds.drop_vars(vars_to_remove)
-
             # Conditionally add channel as a variable using single dimension
             # If channel is used then add chan_assim, chan_nassim, and
             # chan_yaxis to allow plotting of channel markers.
+            # --------------------------------------------------------------
             if 'channel' in group_vars:
                 ds['channel'] = (['Channel'], channo)
                 ds['chan_assim'] = (['Channel'], chan_assim)
                 ds['chan_nassim'] = (['Channel'], chan_nassim)
-                ds['chan_yaxis'] = (['Channel'], [-100]*len(channo))
+                ds['chan_yaxis_100'] = (['Channel'], [-100]*len(channo))
+                ds['chan_yaxis_3'] = (['Channel'], [-3]*len(channo))
 
             # Conditionally add scan position as a variable using single dimension
+            # --------------------------------------------------------------------
             if 'scan' in group_vars:
                 ds['scan'] = (['scan'], scanpo)
+
+            # Drop data variables not in user requested variables
+            # ---------------------------------------------------
+            vars_to_remove = list(set(list(ds.keys())) - set(group_vars))
+            ds = ds.drop_vars(vars_to_remove)
 
             # Rename variables with group
             rename_dict = {}

--- a/src/eva/data/mon_data_space.py
+++ b/src/eva/data/mon_data_space.py
@@ -37,7 +37,8 @@ class MonDataSpace(EvaBase):
         # Get control file and parse
         # --------------------------
         control_file = get(dataset_config, self.logger, 'control_file')
-        coords, dims, attribs, nvars, vars, channo, scanpo = self.get_ctl_dict(control_file[0])
+        coords, dims, attribs, nvars, vars, channo, scanpo, chan_assim, chan_nassim = (
+                                                      self.get_ctl_dict(control_file[0]))
         ndims_used, dims_arr = self.get_ndims_used(dims)
 
         # Get the groups to be read
@@ -125,8 +126,13 @@ class MonDataSpace(EvaBase):
             ds = ds.drop_vars(vars_to_remove)
 
             # Conditionally add channel as a variable using single dimension
+            # If channel is used then add chan_assim, chan_nassim, and
+            # chan_yaxis to allow plotting of channel markers.
             if 'channel' in group_vars:
                 ds['channel'] = (['Channel'], channo)
+                ds['chan_assim'] = (['Channel'], chan_assim)
+                ds['chan_nassim'] = (['Channel'], chan_nassim)
+                ds['chan_yaxis'] = (['Channel'], [-100]*len(channo))
 
             # Conditionally add scan position as a variable using single dimension
             if 'scan' in group_vars:
@@ -196,6 +202,8 @@ class MonDataSpace(EvaBase):
         vars = []
         nvars = 0
         channo = []
+        chan_assim = []
+        chan_nassim = []
         scanpo = None
         scan_info = []
 
@@ -204,7 +212,7 @@ class MonDataSpace(EvaBase):
                      'scan': 'Scan',
                      'pressure': 'Level',
                      'region': 'Region',
-                     'iter': 'Iteration'
+                     'iter': 'Iteration',
         }
 
         with open(control_file, 'r') as fp:
@@ -258,10 +266,18 @@ class MonDataSpace(EvaBase):
                 # Note we need to extract the actual channel numbers.  We have the
                 # number of channels via the xdef line, but they are not necessarily
                 # ordered consecutively.
+                #
+                # If channel is used then assign channel numbers to the chan_assim and
+                # chan_nassim arrays based on the channel's iuse setting in the control
+                # file.  In the file 1 = assimilated, -1 = not assimilated.
                 if line.find('channel=') != -1:
                     strs = line.split()
                     if strs[4].isdigit():
                         channo.append(int(strs[4]))
+                    if strs[7] == '1':
+                        chan_assim.append(int(strs[4]))
+                    if strs[7] == '-1':
+                        chan_nassim.append(int(strs[4]))
 
             # The list of variables is at the end of the file between the lines
             # "vars" and "end vars".
@@ -286,7 +302,17 @@ class MonDataSpace(EvaBase):
                 for x in range(1, int(scan_info[0])):
                     scanpo.append(float(scan_info[1])+(float(scan_info[2])*x))
 
-        return coords, dims, attribs, nvars, vars, channo, scanpo
+            # If Channel is in the coords then pad out the chan_assim adn chan_nassim
+            # arrays with zeros.  They need to be the correct length to use 'Channel' as
+            # the dimension.  Also the yaml file can use the 'select where' transform
+            # to drop all values < 1 and plot only the assim/nassim channel markers.
+            if 'Channel' in coords.values():
+                for x in range(len(chan_assim), len(channo)):
+                    chan_assim.append(0)
+                for x in range(len(chan_nassim), len(channo)):
+                    chan_nassim.append(0)
+
+        return coords, dims, attribs, nvars, vars, channo, scanpo, chan_assim, chan_nassim
 
     def read_ieee(self, file_name, coords, dims, ndims_used, dims_arr, nvars, vars, file_path=None):
 


### PR DESCRIPTION
## Description

Extend `src/eva/data/mon_data_space.py` to support channel markers.  

If Channel is specified as a dimension in the control file then create three variables in the dataset, `chan_assim`, `chan_nassim`, `chan_yaxis`.  These may be used by the yaml file to plot channel markers.  

The `chan_assim` and `chan_nassim` arrays contain the channel numbers that are assimilated and not assimilated respectively.  Both arrays are padded to 'Channel' length with 0 values, so the yaml file can perform an `accept where` transform to get only those channels that are assimilated and/or not assimilated.  The chan_yaxis provides a constant y axis value of -100 for the channel markers.

Example plot using these changes:

![image](https://github.com/JCSDA-internal/eva/assets/62339196/d5615ab1-c88a-4206-ae99-0abbfd418346)

## Dependencies
None

## Impact

None

Completes #110 