### PR TITLE
Feature/fix chan 120

### DIFF
--- a/src/eva/data/mon_data_space.py
+++ b/src/eva/data/mon_data_space.py
@@ -129,7 +129,8 @@ class MonDataSpace(EvaBase):
                 ds['chan_assim'] = (['Channel'], chan_assim)
                 ds['chan_nassim'] = (['Channel'], chan_nassim)
                 ds['chan_yaxis_100'] = (['Channel'], [-100]*len(channo))
-                ds['chan_yaxis_3'] = (['Channel'], [-3]*len(channo))
+                ds['chan_yaxis_1p5'] = (['Channel'], [-1.5]*len(channo))
+                ds['chan_yaxis_p05'] = (['Channel'], [-0.05]*len(channo))
 
             # Conditionally add scan position as a variable using single dimension
             # --------------------------------------------------------------------
@@ -347,7 +348,7 @@ class MonDataSpace(EvaBase):
             rtn_array = np.empty((0, dims[dims_arr[0]], dims[dims_arr[1]]), float)
             if not load_data:
                 zarray = np.zeros((dims[dims_arr[0]], dims[dims_arr[1]]), float)
-            dimensions = [dims[dims_arr[0]], dims[dims_arr[1]]]
+            dimensions = [dims[dims_arr[1]], dims[dims_arr[0]]]
 
         if ndims_used == 3:		# RadMon angle
             rtn_array = np.empty((0, dims[dims_arr[0]], dims[dims_arr[1]],
@@ -383,7 +384,7 @@ class MonDataSpace(EvaBase):
                     if ndims_used == 1:
                         arr = np.fromfile(file_name, dtype='f4').reshape(dimensions)
                     else:
-                        arr = f.read_reals(dtype=np.dtype('>f4')).reshape(dimensions)
+                        arr = np.transpose(f.read_reals(dtype=np.dtype('>f4')).reshape(dimensions))
                 else:
                     arr = zarray
                 rtn_array = np.append(rtn_array, [arr], axis=0)


### PR DESCRIPTION
## Description

The problems with non-continuous channels turned out to be a data load issue instead.  My row-major brain hadn't quite figured out the correct dimension order for reading the binary files.  Fixing that fixed the channel assignment issues, and the summary plots now are in very close agreement with the legacy RadMon summary plots (see below).  I had thought the earlier discrepancies in the eva plots might be due to incorrectly purging missing data but the problem was more fundamental. 

Eva plot for abi_g16 at 2023070218:
![image](https://github.com/JCSDA-internal/eva/assets/62339196/7cc2afca-3493-4300-9b24-6e2890d5d248)

Legacy RadMon summary plot for abi_g16 at 2302307:
![image](https://github.com/JCSDA-internal/eva/assets/62339196/355c15f4-cf23-4b46-a753-d5367becf40e)

The eva plot is using 'tight layout' and it makes a difference.  Also worth noting, multi-line titles work but the yaml must use " not ' for strings in order to recognize the newline (\n) character.

I added two additional horizontal lines to optimally position the channel markers.

## Dependencies

None

## Impact

None

Completes #120 