### PR TITLE
Fix Channel usage in mon_data_space.py

### DIFF
--- a/src/eva/data/mon_data_space.py
+++ b/src/eva/data/mon_data_space.py
@@ -87,7 +87,7 @@ class MonDataSpace(EvaBase):
             timestep_ds = None
 
             timestep_ds = self.load_dset(vars, nvars, coords, darr, dims, ndims_used,
-                                         dims_arr, x_range, y_range, z_range, cyc_darr)
+                                         dims_arr, x_range, y_range, z_range, cyc_darr, channo)
 
             if attribs['sat']:
                 timestep_ds.attrs['satellite'] = attribs['sat']
@@ -461,7 +461,7 @@ class MonDataSpace(EvaBase):
     # ----------------------------------------------------------------------------------------------
 
     def load_dset(self, vars, nvars, coords, darr, dims, ndims_used,
-                  dims_arr, x_range, y_range, z_range, cyc_darr):
+                  dims_arr, x_range, y_range, z_range, cyc_darr, channo):
 
         # create dataset from file components
         rtn_ds = None
@@ -482,6 +482,9 @@ class MonDataSpace(EvaBase):
                                        coords[dims_arr[2]]),
                               "data": darr[x, :, :]}
                 }
+
+            if 'Channel' in coords.values():
+                d.update({"Channel": {"dims": ("Channel"), "data": channo}})
 
             new_ds = Dataset.from_dict(d)
             rtn_ds = new_ds if rtn_ds is None else rtn_ds.merge(new_ds)


### PR DESCRIPTION
This fix allows `mon_data_space.py` to use the actual channel numbers in the dataset coordinates.  Yaml files using `mon_data_space.py` should now only use the actual channel numbers in the `channels` specification.

Testing has been done using abi_g16 data (valid chans 7-16), and hirs4_metop-a data (valid chans 1-19).  

## Dependencies

None

## Impact

None


Closes #129 