### PR TITLE
Extend mon_data_space.py to support MinMon binary data

### DIFF
--- a/src/eva/data/mon_data_space.py
+++ b/src/eva/data/mon_data_space.py
@@ -9,7 +9,6 @@
 
 # --------------------------------------------------------------------------------------------------
 
-import struct
 import os
 import numpy as np
 import array
@@ -450,9 +449,7 @@ class MonDataSpace(EvaDatasetBase):
                 levs_dict = {'levels': levs,
                              'levels_assim': level_assim,
                              'levels_nassim': level_nassim}
-
             fp.close()
-
         return coords, dims, attribs, nvars, vars, scanpo, levs_dict, chans_dict
 
     # ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Extend `data/mon_data_space.py` to support MinMon binary data files and 'iteration' as a dimension.  Additionally an error in coordinate assignment was fixed (see 'new_coords' changes in code).



This will close #161 .