### PR TITLE
Correct zdef dimension

### DIFF
--- a/src/eva/data/mon_data_space.py
+++ b/src/eva/data/mon_data_space.py
@@ -883,7 +883,7 @@ class MonDataSpace(EvaDatasetBase):
         if dims['ydef'] > 0:
             y_range = channo if coords['ydef'] == 'Channel' else np.arange(1, dims['ydef']+1)
 
-        if dims['zdef'] > 1:
+        if dims['zdef'] > 0:
             z_range = np.arange(1, dims['zdef']+1)
 
         return x_range, y_range, z_range


### PR DESCRIPTION
Change check value on `zdef `dimension.  This is needed for observation data, particularly ps obs which have only a single zdef (level) value.  

This change has been tested with Ozn, Rad, and Min data and all work correctly.