### PR TITLE
Add check on control file and graceful exit,

### DIFF
--- a/requirements-github.txt
+++ b/requirements-github.txt
@@ -1,7 +1,7 @@
 pyyaml>=6.0
 pycodestyle>=2.9.1
 netCDF4>=1.6.1
-matplotlib==3.5.2
+matplotlib==3.7.1
 cartopy>=0.21.1
 scikit-learn>=1.1.2
 xarray>=2022.6.0

--- a/src/eva/data/mon_data_space.py
+++ b/src/eva/data/mon_data_space.py
@@ -63,6 +63,10 @@ class MonDataSpace(EvaDatasetBase):
         # Get control file and parse
         # --------------------------
         control_file = get(dataset_config, self.logger, 'control_file')
+        if not os.path.isfile(control_file[0]):
+            self.logger.info(f'Warning: control file {control_file[0]} not found, unable' +
+                             ' to plot')
+            exit(1)
 
         dims_arr = []
         if self.is_stn_data(control_file[0]):


### PR DESCRIPTION
Modity `mon_data_space.py` adding a check on the control file and graceful exit if not found.  Without this exit the entire plot job terminates.  With this exit only the affected thread halts (with error message), allowing all other plots to proceed.  

This has been tested on wcoss2 by removing some control files from the test data set.  Missing control files are reported as warnings and all plots with valid control files run to completion.

## Dependencies

None

Resolves #191 .
