### PR TITLE
Fix time precision warning on hera

### DIFF
--- a/src/eva/data/csv_space.py
+++ b/src/eva/data/csv_space.py
@@ -156,4 +156,6 @@ class CsvSpace(EvaDatasetBase):
                               " \'year\': int, \'month\': int, \'day\': int, and \'hour\': int. " +
                               f" Date information found was {date_config}")
 
-        return np.array([np.datetime64(datetime.strptime(ds, '%Y%m%d%H')) for ds in date_str_list])
+        return np.array([np.datetime64(datetime.strptime(ds,
+                                       '%Y%m%d%H').strftime('%Y-%m-%dT%H:%M:%S.%f000000'),
+                                       'ns') for ds in date_str_list])


### PR DESCRIPTION
With the rocky8 update `csv_space.py` produced a warning message about the precision of datatime64 data.  Using nanosecond precision formatting fixes this warning.

Testing has been done on both hera and wcoss2 (which didn't have any issue with the datetime64 format and is ok with nanosecond formatting).


Closes #190 
