### PR TITLE
Fix config error with emcpy_horizontal_line.py Ref

### DIFF
--- a/src/eva/plotting/batch/emcpy/diagnostics/emcpy_horizontal_line.py
+++ b/src/eva/plotting/batch/emcpy/diagnostics/emcpy_horizontal_line.py
@@ -43,7 +43,8 @@ class EmcpyHorizontalLine(HorizontalLine):
         delvars = ['type', 'schema']
         for d in delvars:
             new_config.pop(d, None)
-        self.plotobj = update_object(self.plotobj, self.config, self.logger)
+
+        self.plotobj = update_object(self.plotobj, new_config, self.logger)
 
         return self.plotobj
 

--- a/src/eva/plotting/batch/emcpy/diagnostics/emcpy_horizontal_line.py
+++ b/src/eva/plotting/batch/emcpy/diagnostics/emcpy_horizontal_line.py
@@ -43,7 +43,6 @@ class EmcpyHorizontalLine(HorizontalLine):
         delvars = ['type', 'schema']
         for d in delvars:
             new_config.pop(d, None)
-
         self.plotobj = update_object(self.plotobj, new_config, self.logger)
 
         return self.plotobj


### PR DESCRIPTION
Fix horizontal line config error.  Use the correct config information in the plot object.

I ran into this issue last week but assumed it had to be an install issue, not a simple coding error.  I'm not sure how/why this worked as long as it did.  Maybe the unrecognized variable in the plot object is ok in python3 environments that aren't on Rocky8? 

Close #203 
