### PR TITLE
Fix 4 problems in mon_data_space and map-scatter plots

### DIFF
--- a/src/eva/data/mon_data_space.py
+++ b/src/eva/data/mon_data_space.py
@@ -800,7 +800,9 @@ class MonDataSpace(EvaDatasetBase):
             f.close()
 
         else:
-            rtn_array = np.zeros((len(vars), 1, 1), float)
+            rtn_array = np.zeros((len(vars), dims[dims_arr[0]], 1), float)
+            lat.append(0)
+            lon.append(0)
             dims['ydef'] = 1
 
         rtn_lat = np.asarray(lat).reshape(-1)

--- a/src/eva/plotting/batch/base/diagnostics/map_scatter.py
+++ b/src/eva/plotting/batch/base/diagnostics/map_scatter.py
@@ -51,18 +51,24 @@ class MapScatter(ABC):
     def data_prep(self):
         """ Preparing data for configure_plot  """
 
+        # Optionally get the channel|level|datatype to plot
         channel = None
         if 'channel' in self.config['data']:
             channel = self.config['data'].get('channel')
+        level = None
+        if 'level' in self.config:
+            level = self.config.get('level')
+
         lonvar_cgv = self.config['longitude']['variable'].split('::')
         lonvar = self.dataobj.get_variable_data(lonvar_cgv[0], lonvar_cgv[1], lonvar_cgv[2], None)
         lonvar = slice_var_from_str(self.config['longitude'], lonvar, self.logger)
         latvar_cgv = self.config['latitude']['variable'].split('::')
         latvar = self.dataobj.get_variable_data(latvar_cgv[0], latvar_cgv[1], latvar_cgv[2], None)
         latvar = slice_var_from_str(self.config['latitude'], latvar, self.logger)
+
         datavar_cgv = self.config['data']['variable'].split('::')
         datavar = self.dataobj.get_variable_data(datavar_cgv[0], datavar_cgv[1],
-                                                 datavar_cgv[2], channel)
+                                                 datavar_cgv[2], channel, level)
         datavar = slice_var_from_str(self.config['data'], datavar, self.logger)
         self.lonvar = lonvar.flatten()
         self.latvar = latvar.flatten()

--- a/src/eva/plotting/batch/base/plot_tools/dynamic_config.py
+++ b/src/eva/plotting/batch/base/plot_tools/dynamic_config.py
@@ -74,7 +74,8 @@ def vminvmaxcmap(logger, option_dict, plots_dict, data_collections):
                                                  varname_cgv[2], channel, level, datatype)
 
     # Reorder the data array
-    datavar = np.sort(datavar)
+    if datavar.size > 1:
+        datavar = np.sort(datavar)
 
     # Decide how many values to throw out on each end of the dataset
     n = datavar.size

--- a/src/eva/plotting/batch/emcpy/diagnostics/emcpy_map_scatter.py
+++ b/src/eva/plotting/batch/emcpy/diagnostics/emcpy_map_scatter.py
@@ -33,7 +33,7 @@ class EmcpyMapScatter(MapScatter):
         layer_schema = self.config.get('schema', os.path.join(return_eva_path(), 'plotting',
                                        'batch', 'emcpy', 'defaults', 'map_scatter.yaml'))
         new_config = get_schema(layer_schema, self.config, self.logger)
-        delvars = ['longitude', 'latitude', 'data', 'type', 'schema']
+        delvars = ['longitude', 'latitude', 'data', 'type', 'schema', 'level']
         for d in delvars:
             new_config.pop(d, None)
         self.plotobj = update_object(self.plotobj, new_config, self.logger)


### PR DESCRIPTION
This PR fixes these problems:

1. `mon_data_space.py` now adds empty lat and lon values for each level when the requested data file is not found.  A value of `1` was used heretofore, which somehow worked.  It does not work with code built on Rocky8 though, hence this change.
2. `emcpy_map_scatter.py` now removes 'level' from the plot object -- emcpy doesn't recognize level and fails if it's in the plot object's configuration.  How this ever worked is not clear to me, but it does with this change.
3. `dynamic_config.py` now has a check on the data before it tries to sort the data. Without this check when there was no data an exception resulted.
4. `map_scatter.py` now includes `level` when selecting the specific data for a plot.  Without this change only plots with a single level worked; all others had a dimension mismatch and resulting exception in the color bar generation.   This one was totally my fault -- I installed a similar fix in `line_plot.py` months ago and asked myself if I needed to change any other plots?  Nah, don't think so.  Ooops.



Close #205 

