### PR TITLE
Fix plot logo and tight layout bug

### DIFF
--- a/src/eva/plotting/batch/base/plot_tools/figure_driver.py
+++ b/src/eva/plotting/batch/base/plot_tools/figure_driver.py
@@ -241,8 +241,11 @@ def make_figure(handler, figure_conf, plots, dynamic_options, data_collections, 
             fig.tight_layout(**figure_conf['tight layout'])
         else:
             fig.tight_layout()
+        figure_conf.pop('tight layout')
+
     if 'plot logo' in figure_conf:
         fig.plot_logo(**figure_conf['plot logo'])
+        figure_conf.pop('plot logo')
 
     saveargs = get_saveargs(figure_conf)
     fig.save_figure(output_file, **saveargs)

--- a/src/eva/tests/config/testMonDataSpaceHirs4Metop-A.yaml
+++ b/src/eva/tests/config/testMonDataSpaceHirs4Metop-A.yaml
@@ -30,9 +30,10 @@ graphics:
         figure size: [12,10]
         title: 'hirs4_metop-a | Channel 1 | Obs Count'
         output name: lineplots/hirs4_metop-a/hirs4_metop-a.0.count.png
-        #plot logo:
-        #  which: 'noaa/nws'
-        #  loc: 'upper right'
+        plot logo:
+          which: 'noaa/nws'
+          loc: 'upper right'
+        tight layout:
       plots:
         - add_xlabel: 'Cycle Time'
           add_ylabel: 'Observation Count'


### PR DESCRIPTION
Fix the fatal error that results from a batch plot input yaml file containing `plot logo` and/or `tight layout` figure settings.

As described in #212 the problem is that in `src/eva/plotting/batch/base/plot_tools/figure_driver.py` both `plot logo` and `tight layout` are left in the `figure_conf` dictionary after the corresponding figure method is correctly applied.  The `figure_conf` dictionary is eventually fed to `emcpy` and then `matplotlib` which is unable to parse these entries.  The fix is to simply remove the entries from `figure_conf` once the requested method has been called.

Testing has been done on hera using `src/eva/tests/config/testMonDataSpaceHirs4Metop-A.yaml`, which now can plot logos and use tight layout.

Closes #212 
