### PR TITLE
Modify jedi_variational_bias_correction to support multiple data files in input yaml specification

### DIFF
--- a/src/eva/data/jedi_variational_bias_correction.py
+++ b/src/eva/data/jedi_variational_bias_correction.py
@@ -62,8 +62,8 @@ class JediVariationalBiasCorrection(EvaDatasetBase):
         # Check for required keys in config
         required_keys = [
             'name',
-            'bias_file',
-            'lapse_file',
+            'bias_files',
+            'lapse_files',
             ]
         for key in required_keys:
             self.logger.assert_abort(key in dataset_config, "For JediVariationalBiasCorrection " +
@@ -71,60 +71,69 @@ class JediVariationalBiasCorrection(EvaDatasetBase):
 
         # Parse config
         collection_name = dataset_config['name']
-        bias_file = get(dataset_config, self.logger, 'bias_file')
-        lapse_file = get(dataset_config, self.logger, 'lapse_file')
+        bias_files = get(dataset_config, self.logger, 'bias_files')
+        lapse_files = get(dataset_config, self.logger, 'lapse_files')
+
+        # Verify same number of bais_files and lapse_files
+        self.logger.assert_abort(len(bias_files) == len(lapse_files), 'The number of bias_files '
+                                 'and lapse_files in the input yaml file must be the same.')
 
         groups = [
             'BiasCoefficients',
             'BiasCoefficientErrors',
         ]
 
+        ds_groups = xr.Dataset()
+
         # Create a new dataset to store the bias data
-        bias_dataset = xr.open_dataset(bias_file)
+        for bfile, lfile in zip(bias_files, lapse_files):
+            bias_dataset = xr.open_dataset(bfile)
 
-        # Get record dimension size
-        self.logger.assert_abort(len(bias_dataset['Record']) == 1, 'This code currently only  '
-                                 'supports reading VarBC files where the Record diminsion is 1')
+            # Get record dimension size
+            self.logger.assert_abort(len(bias_dataset['Record']) == 1, 'This code currently only  '
+                                     'supports reading VarBC files where the Record diminsion is 1')
 
-        # Loop over groups, open and store in bias_dataset
-        for group in groups:
-            dsg = xr.open_dataset(bias_file, group=group)
+            # Loop over groups, open and store in bias_dataset
+            for group in groups:
+                dsg = xr.open_dataset(bfile, group=group)
 
-            # Rename variables with group
-            dsg = dsg.rename_vars({var: f'{group}::{var}' for var in dsg.data_vars})
+                # Rename variables with group
+                dsg = dsg.rename_vars({var: f'{group}::{var}' for var in dsg.data_vars})
 
-            # Store the data in the bias_dataset
-            bias_dataset = xr.merge([bias_dataset, dsg])
+                # Store the data in the bias_dataset
+                bias_dataset = xr.merge([bias_dataset, dsg])
 
-        # Now add coordinate for channels dimension going from 0 to channel
-        bias_dataset = bias_dataset.assign_coords(
-            {'Channel': range(len(bias_dataset.Channel))}
-        )
+            # Now add coordinate for channels dimension going from 0 to channel
+            bias_dataset = bias_dataset.assign_coords(
+                {'Channel': range(len(bias_dataset.Channel))}
+            )
 
-        # Squeeze the record dimension and remove record coordinate
-        bias_dataset = bias_dataset.squeeze('Record')
-        bias_dataset = bias_dataset.drop_vars('Record')
+            # Squeeze the record dimension and remove record coordinate
+            bias_dataset = bias_dataset.squeeze('Record')
+            bias_dataset = bias_dataset.drop_vars('Record')
 
-        # Rename numberObservationsUsed to Bias::numberObservationsUsed
-        bias_dataset = bias_dataset.rename_vars(
-            {'numberObservationsUsed': 'Bias::numberObservationsUsed'}
-        )
+            # Rename numberObservationsUsed to Bias::numberObservationsUsed
+            bias_dataset = bias_dataset.rename_vars(
+                {'numberObservationsUsed': 'Bias::numberObservationsUsed'}
+            )
 
-        # Remove attrributes from the dataset
-        bias_dataset.attrs = {}
+            # Remove attrributes from the dataset
+            bias_dataset.attrs = {}
 
-        # Read the t-lapse file (text) into a dataset
-        with open(lapse_file, 'r') as f:
-            lapse_data = f.readlines()
+            # Read the t-lapse file (text) into a dataset
+            with open(lfile, 'r') as f:
+                lapse_data = f.readlines()
 
-        # Store the third element of each line as numpy array
-        lapse_data = np.array([float(line.split()[2]) for line in lapse_data])
+            # Store the third element of each line as numpy array
+            lapse_data = np.array([float(line.split()[2]) for line in lapse_data])
 
-        # Store lapse data in flat_dataset with channel as dimension/coordinate
-        bias_dataset['Bias::tlapse'] = xr.DataArray(lapse_data, dims=['Channel'])
+            # Store lapse data in flat_dataset with channel as dimension/coordinate
+            # and merge to ds_groups
+            bias_dataset['Bias::tlapse'] = xr.DataArray(lapse_data, dims=['Channel'])
+            ds_groups = ds_groups.merge(bias_dataset)
 
-        # Add bias_dataset to data_collections
-        data_collections.create_or_add_to_collection(collection_name, bias_dataset)
+        # Add ds_groups to data_collections
+        data_collections.create_or_add_to_collection(collection_name, ds_groups, 'Channel')
 
     # ----------------------------------------------------------------------------------------------
 
@@ -148,8 +157,8 @@ class JediVariationalBiasCorrection(EvaDatasetBase):
         """
 
         return {
-            'bias_file': filenames[0],
-            'lapse_file': filenames[1],
+            'bias_files': [filenames[0]],
+            'lapse_files': [filenames[1]],
             'name': collection_name
             }
 

--- a/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
+++ b/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
@@ -4,25 +4,26 @@ datasets:
   - name: experiment
     type: JediVariationalBiasCorrection
     bias_files:
-      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.satbias
-      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.satbias
+      - ../data/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.satbias
+      - ../data/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.satbias
     lapse_files:
-      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.tlapse
-      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.tlapse
+      - ../data/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.tlapse
+      - ../data/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.tlapse
 
   # Empty
   - name: experiment
     type: JediVariationalBiasCorrection
     bias_files:
-      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.satbias
+      - ../data/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.satbias
     lapse_files:
-      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.tlapse
+      - ../data/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.tlapse
 
 time_series:
 
   - begin_date: '2021-12-11T15:00:00'
     final_date: '2021-12-12T03:00:00'
     interval: 'PT6H'
+-
     collection: experiment
     variables:
       - all

--- a/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
+++ b/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
@@ -3,26 +3,27 @@ suppress_collection_display: False
 datasets:
   - name: experiment
     type: JediVariationalBiasCorrection
-    bias_files:
-      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.satbias
-      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.satbias
-    lapse_files:
-      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.tlapse
-      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.tlapse
+    bias_files: 
+      - ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.satbias
+      - ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.satbias
+    lapse_files: 
+      - ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.tlapse
+      - ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.tlapse
 
   # Empty
   - name: experiment
     type: JediVariationalBiasCorrection
-    bias_files:
-      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.satbias
-    lapse_files:
-      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.tlapse
+    bias_files: 
+      - ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.satbias
+    lapse_files: 
+      - ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.tlapse
 
 time_series:
 
   - begin_date: '2021-12-11T15:00:00'
     final_date: '2021-12-12T03:00:00'
     interval: 'PT6H'
+
     collection: experiment
     variables:
       - all

--- a/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
+++ b/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
@@ -23,7 +23,7 @@ time_series:
   - begin_date: '2021-12-11T15:00:00'
     final_date: '2021-12-12T03:00:00'
     interval: 'PT6H'
--
+
     collection: experiment
     variables:
       - all

--- a/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
+++ b/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
@@ -23,7 +23,6 @@ time_series:
   - begin_date: '2021-12-11T15:00:00'
     final_date: '2021-12-12T03:00:00'
     interval: 'PT6H'
-
     collection: experiment
     variables:
       - all

--- a/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
+++ b/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
@@ -3,19 +3,20 @@ suppress_collection_display: False
 datasets:
   - name: experiment
     type: JediVariationalBiasCorrection
-    bias_file: ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.satbias
-    lapse_file: ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.tlapse
-
-  - name: experiment
-    type: JediVariationalBiasCorrection
-    bias_file: ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.satbias
-    lapse_file: ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.tlapse
+    bias_files: 
+      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.satbias
+      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.satbias
+    lapse_files: 
+      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.tlapse
+      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.tlapse
 
   # Empty
   - name: experiment
     type: JediVariationalBiasCorrection
-    bias_file: ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.satbias
-    lapse_file: ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.tlapse
+    bias_files: 
+      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.satbias
+    lapse_files: 
+      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.tlapse
 
 time_series:
 

--- a/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
+++ b/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
@@ -3,19 +3,19 @@ suppress_collection_display: False
 datasets:
   - name: experiment
     type: JediVariationalBiasCorrection
-    bias_files: 
+    bias_files:
       - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.satbias
       - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.satbias
-    lapse_files: 
+    lapse_files:
       - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.tlapse
       - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.tlapse
 
   # Empty
   - name: experiment
     type: JediVariationalBiasCorrection
-    bias_files: 
+    bias_files:
       - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.satbias
-    lapse_files: 
+    lapse_files:
       - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.tlapse
 
 time_series:
@@ -23,7 +23,6 @@ time_series:
   - begin_date: '2021-12-11T15:00:00'
     final_date: '2021-12-12T03:00:00'
     interval: 'PT6H'
-
     collection: experiment
     variables:
       - all

--- a/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
+++ b/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
@@ -3,19 +3,19 @@ suppress_collection_display: False
 datasets:
   - name: experiment
     type: JediVariationalBiasCorrection
-    bias_files: 
+    bias_files:
       - ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.satbias
       - ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.satbias
-    lapse_files: 
+    lapse_files:
       - ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.tlapse
       - ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.tlapse
 
   # Empty
   - name: experiment
     type: JediVariationalBiasCorrection
-    bias_files: 
+    bias_files:
       - ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.satbias
-    lapse_files: 
+    lapse_files:
       - ${data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.tlapse
 
 time_series:

--- a/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
+++ b/src/eva/tests/config/testJediVariationalBiasCorrectionAmsuaN19.yaml
@@ -4,19 +4,19 @@ datasets:
   - name: experiment
     type: JediVariationalBiasCorrection
     bias_files:
-      - ../data/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.satbias
-      - ../data/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.satbias
+      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.satbias
+      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.satbias
     lapse_files:
-      - ../data/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.tlapse
-      - ../data/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.tlapse
+      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T15:00:00Z.tlapse
+      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-11T21:00:00Z.tlapse
 
   # Empty
   - name: experiment
     type: JediVariationalBiasCorrection
     bias_files:
-      - ../data/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.satbias
+      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.satbias
     lapse_files:
-      - ../data/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.tlapse
+      - {data_input_path}/gsi.x0048v2.bc.amsua_n19.2021-12-12T03:00:00Z.tlapse
 
 time_series:
 

--- a/src/eva/time_series/time_series_utils.py
+++ b/src/eva/time_series/time_series_utils.py
@@ -8,7 +8,7 @@ from eva.data.data_collections import DataCollections
 filename_retrieval = {
     "GsiObsSpace": lambda dataset_config: dataset_config["filenames"],
     "IodaObsSpace": lambda dataset_config: dataset_config["filenames"],
-    "JediVariationalBiasCorrection": lambda dataset_config: dataset_config["bias_file"],
+    "JediVariationalBiasCorrection": lambda dataset_config: dataset_config["bias_files"],
 }
 
 


### PR DESCRIPTION
Allow jedi_variational_bias_correction object to support multiple input files per group in the input yaml file.  The bias and lapse files are now loaded into an intermediate dataset group structure iteratively before the dataset group is added to the main data_collection object.  This follows similar patterns in the various data objects that support multiple input files within a specified experiment/group.

Additionally catch a mismatch in the number of specified bias and lapse files and abort with appropriate error message.


Closes #225 