### PR TITLE
Add std capability for time_series.

### DIFF
--- a/src/eva/time_series/time_series.py
+++ b/src/eva/time_series/time_series.py
@@ -22,6 +22,7 @@ xr_aggregation_methods = {
     'mean': lambda ds, dim: ds.mean(dim=dim, skipna=True),
     'sum': lambda ds, dim: ds.sum(dim=dim, skipna=True),
     'count': lambda ds, dim: ds.count(dim=dim),
+    'std': lambda ds, dim: ds.std(dim=dim, skipna=True),
 }
 
 


### PR DESCRIPTION
## Description
There are some eva templates I've been passing around at GMAO that require this change to plot a time series of radiance O-F/O-A standard deviation/cycle. It would help me out to add this one line, so I don't need to tell people to go around editing their eva installs. 



## Dependencies
None

## Impact
None

