### PR TITLE
Fix bug in transform collection name sourcing

### DIFF
--- a/src/eva/eva_driver.py
+++ b/src/eva/eva_driver.py
@@ -159,8 +159,14 @@ def read_transform_time_series(logger, timing, eva_dict, data_collections):
         transform_dict = defaultdict(list)
         if 'transforms' in eva_dict:
             for transform in get(eva_dict, logger, 'transforms'):
+
                 # Get collection name
-                name = transform['new name'].split('::')[0]
+                name = None
+                if 'new name' in transform:
+                    name = transform['new name'].split('::')[0]
+                elif 'variable_name' in transform:
+                    name = transform['variable_name'].split('::')[0]
+
                 if name == time_series_config['collection']:
                     transform_dict['transforms'].append(transform)
 


### PR DESCRIPTION
Fix bug in check on transform collection name.  The search was done using 'new name' which is present in _most_ transforms but it isn't in `channel_stats`.  Add a check that picks up the collection name for `channel_stats` transforms.


Closes #237