### PR TITLE
Add confidence interval capability to arithmetic

### DIFF
--- a/src/eva/tests/config/testIodaObsSpaceAmsuaN19_Channel_Stats_Confidence.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceAmsuaN19_Channel_Stats_Confidence.yaml
@@ -1,0 +1,222 @@
+suppress_collection_display: false
+datasets:
+- name: control
+  type: IodaObsSpace
+  filenames:
+  - ${data_input_path}/ctrl_amsua_n19.20230726T030000Z.nc4
+  channels: 3,8
+  groups:
+  - name: ObsValue
+    variables:
+    - brightnessTemperature
+  - name: GsiHofXBc
+  - name: hofx0
+  - name: MetaData
+  - name: oman
+- name: experiment
+  type: IodaObsSpace
+  filenames:
+  - ${data_input_path}/exp_amsua_n19.20230726T030000Z.nc4
+  channels: 3,8
+  groups:
+  - name: ObsValue
+    variables:
+    - brightnessTemperature
+  - name: GsiHofXBc
+  - name: hofx0
+  - name: MetaData
+  - name: oman
+transforms:
+- transform: arithmetic
+  new name: control::ObsValueMinusHofx::brightnessTemperature
+  equals: control::ObsValue::brightnessTemperature-control::hofx0::brightnessTemperature
+- transform: arithmetic
+  new name: experiment::ObsValueMinusHofx::brightnessTemperature
+  equals: experiment::ObsValue::brightnessTemperature-experiment::hofx0::brightnessTemperature
+
+# get channel stats for OmB experiment
+- transform: channel_stats
+  channel_dimension_name: Location
+  statistic list:
+  - Mean
+  - Count
+  - Std
+  variable_name: experiment::ObsValueMinusHofx::${variable}
+  for:
+    variable:
+    - brightnessTemperature
+
+# get channel stats for OmB control
+- transform: channel_stats
+  channel_dimension_name: Location
+  statistic list:
+  - Mean
+  - Count
+  - Std
+  variable_name: control::ObsValueMinusHofx::${variable}
+  for:
+    variable:
+    - brightnessTemperature
+
+# Get experiment confidence interval
+- transform: arithmetic
+  new name: experiment::ObsValueMinusHofxError::brightnessTemperature
+  equals: experiment::ObsValueMinusHofxStd::brightnessTemperature/sqrt(experiment::ObsValueMinusHofxCount::brightnessTemperature)*scipy_t_ppf(1-0.05/2,experiment::ObsValueMinusHofxCount::brightnessTemperature)
+
+# Get control confidence interval
+- transform: arithmetic
+  new name: control::ObsValueMinusHofxError::brightnessTemperature
+  equals: control::ObsValueMinusHofxStd::brightnessTemperature/sqrt(control::ObsValueMinusHofxCount::brightnessTemperature)*scipy_t_ppf(1-0.05/2,control::ObsValueMinusHofxCount::brightnessTemperature)
+
+# Apply confidence interval to get upper limit experiment
+- transform: arithmetic
+  new name: experiment::ObsValueMinusHofxMax::brightnessTemperature
+  equals: experiment::ObsValueMinusHofxMean::brightnessTemperature+experiment::ObsValueMinusHofxError::brightnessTemperature
+
+# Apply confidence interval to get lower limit experiment
+- transform: arithmetic
+  new name: experiment::ObsValueMinusHofxMin::brightnessTemperature
+  equals: experiment::ObsValueMinusHofxMean::brightnessTemperature-experiment::ObsValueMinusHofxError::brightnessTemperature
+ 
+# Apply confidence interval to get upper limit control
+- transform: arithmetic
+  new name: control::ObsValueMinusHofxMax::brightnessTemperature
+  equals: control::ObsValueMinusHofxMean::brightnessTemperature+control::ObsValueMinusHofxError::brightnessTemperature
+
+# Apply confidence interval to get lower limit control
+- transform: arithmetic
+  new name: control::ObsValueMinusHofxMin::brightnessTemperature
+  equals: control::ObsValueMinusHofxMean::brightnessTemperature-control::ObsValueMinusHofxError::brightnessTemperature
+- transform: arithmetic
+
+# calculate ftest ratio confidence interval lower limit
+  new name: rat::ftestLower::brightnessTemperature
+  equals: (experiment::ObsValueMinusHofxStd::brightnessTemperature**2/control::ObsValueMinusHofxStd::brightnessTemperature**2)*scipy_f_ppf(1-0.05/2,experiment::ObsValueMinusHofxCount::brightnessTemperature-1,control::ObsValueMinusHofxCount::brightnessTemperature-1)
+
+# calculate ftest ratio confidence interval upper limit
+- transform: arithmetic
+  new name: rat::ftestUpper::brightnessTemperature
+  equals: (experiment::ObsValueMinusHofxStd::brightnessTemperature**2/control::ObsValueMinusHofxStd::brightnessTemperature**2)*scipy_f_ppf(0.05/2,experiment::ObsValueMinusHofxCount::brightnessTemperature,control::ObsValueMinusHofxCount::brightnessTemperature)
+
+# calculate ftest ratio confidence interval lower limit
+- transform: arithmetic
+  new name: rat::rat::brightnessTemperature
+  equals: experiment::ObsValueMinusHofxStd::brightnessTemperature**2/control::ObsValueMinusHofxStd::brightnessTemperature**2
+
+graphics:
+  plotting_backend: Emcpy
+  figure_list:
+  - figure:
+      layout:
+      - 1
+      - 1
+      title: 'AMSU-A Channel summary w/ confidence Intervals'
+      output name: hofx_vs_channel/amsua_n19/brightness_temperature/amsu-a_channel_summary_mean_w_ci.png
+    plots:
+    - add_xlabel: Observation - Background [K]
+      add_ylabel: Channel
+      set_yticks: [3,8]
+      add_grid: null
+      invert_yaxis: null
+      add_legend:
+        loc: 'upper left'
+      layers:
+      - type: LinePlot
+        y:
+          variable: experiment::MetaData::channelNumber
+        x:
+          variable: experiment::ObsValueMinusHofxMin::brightnessTemperature
+        markersize: 5
+        color: orange
+        alpha: 0.5
+        linestyle: dashed
+        label: 
+      - type: LinePlot
+        y:
+          variable: experiment::MetaData::channelNumber
+        x:
+          variable: experiment::ObsValueMinusHofxMean::brightnessTemperature
+        markersize: 5
+        color: orange
+        label: Experiment
+      - type: LinePlot
+        y:
+          variable: experiment::MetaData::channelNumber
+        x:
+          variable: experiment::ObsValueMinusHofxMax::brightnessTemperature
+        markersize: 5
+        color: orange
+        alpha: 0.5
+        linestyle: dashed
+        label: 
+        y:
+          variable: control::MetaData::channelNumber
+        x:
+          variable: control::ObsValueMinusHofxMin::brightnessTemperature
+        markersize: 5
+        color: deepskyblue
+        alpha: 0.5
+        linestyle: dashed 
+        label: 
+        y:
+          variable: control::MetaData::channelNumber
+        x:
+          variable: control::ObsValueMinusHofxMean::brightnessTemperature
+        markersize: 5
+        color: deepskyblue
+        label: Control
+        y:
+          variable: control::MetaData::channelNumber
+        x:
+          variable: control::ObsValueMinusHofxMax::brightnessTemperature
+        markersize: 5
+        color: deepskyblue
+        alpha: 0.5
+        linestyle: dashed
+        label: 
+
+  - figure:
+      layout:
+      - 1
+      - 1
+      title: 'Ratio of Variance O-B Experiment/Control'
+      output name: hofx_vs_channel/amsua_n19/brightness_temperature/amsu-a_channel_summary_variance_ratio_w_ci.png
+    plots:
+    - add_xlabel: Ratio variance (O-B) Experiment/Control
+      add_ylabel: Channel
+      set_yticks: [3,8]
+      add_grid: null
+      invert_yaxis: null
+      add_legend:
+        loc: 'upper left'
+      layers:
+      - type: LinePlot
+        y:
+          variable: experiment::MetaData::channelNumber
+        x: 
+          variable: rat::ftestLower::brightnessTemperature
+        markersize: 5
+        color: orange
+        alpha: 0.5
+        linestyle: dashed
+        label: 
+      - type: LinePlot
+        y:
+          variable: experiment::MetaData::channelNumber
+        x:
+          variable: rat::rat::brightnessTemperature
+        markersize: 5
+        color: orange
+        alpha: 0.5
+        label: variance(Experiment)/variance(Control)
+      - type: LinePlot
+        y:
+          variable: experiment::MetaData::channelNumber
+        x:
+          variable: rat::ftestUpper::brightnessTemperature
+        markersize: 5
+        color: orange
+        alpha: 0.5
+        linestyle: dashed
+        label: 
+

--- a/src/eva/tests/config/testIodaObsSpaceAmsuaN19_Channel_Stats_Confidence.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceAmsuaN19_Channel_Stats_Confidence.yaml
@@ -130,7 +130,7 @@ graphics:
         color: orange
         alpha: 0.5
         linestyle: dashed
-        label: 
+        label:
       - type: LinePlot
         y:
           variable: experiment::MetaData::channelNumber
@@ -147,9 +147,9 @@ graphics:
         markersize: 5
         color: orange
         alpha: 0.5
-      - type: LinePlot
         linestyle: dashed
-        label: 
+        label:
+      - type: LinePlot
         y:
           variable: control::MetaData::channelNumber
         x:
@@ -159,7 +159,7 @@ graphics:
         alpha: 0.5
         linestyle: dashed
         label:
-      - type: LinePlot 
+      - type: LinePlot
         y:
           variable: control::MetaData::channelNumber
         x:
@@ -176,7 +176,7 @@ graphics:
         color: deepskyblue
         alpha: 0.5
         linestyle: dashed
-        label: 
+        label:
 
   - figure:
       layout:
@@ -196,13 +196,13 @@ graphics:
       - type: LinePlot
         y:
           variable: experiment::MetaData::channelNumber
-        x: 
+        x:
           variable: rat::ftestLower::brightnessTemperature
         markersize: 5
         color: orange
         alpha: 0.5
         linestyle: dashed
-        label: 
+        label:
       - type: LinePlot
         y:
           variable: experiment::MetaData::channelNumber
@@ -221,5 +221,5 @@ graphics:
         color: orange
         alpha: 0.5
         linestyle: dashed
-        label: 
+        label:
 

--- a/src/eva/tests/config/testIodaObsSpaceAmsuaN19_Channel_Stats_Confidence.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceAmsuaN19_Channel_Stats_Confidence.yaml
@@ -77,7 +77,7 @@ transforms:
 - transform: arithmetic
   new name: experiment::ObsValueMinusHofxMin::brightnessTemperature
   equals: experiment::ObsValueMinusHofxMean::brightnessTemperature-experiment::ObsValueMinusHofxError::brightnessTemperature
- 
+
 # Apply confidence interval to get upper limit control
 - transform: arithmetic
   new name: control::ObsValueMinusHofxMax::brightnessTemperature
@@ -147,6 +147,7 @@ graphics:
         markersize: 5
         color: orange
         alpha: 0.5
+      - type: LinePlot
         linestyle: dashed
         label: 
         y:
@@ -156,8 +157,9 @@ graphics:
         markersize: 5
         color: deepskyblue
         alpha: 0.5
-        linestyle: dashed 
-        label: 
+        linestyle: dashed
+        label:
+      - type: LinePlot 
         y:
           variable: control::MetaData::channelNumber
         x:
@@ -165,6 +167,7 @@ graphics:
         markersize: 5
         color: deepskyblue
         label: Control
+      - type: LinePlot
         y:
           variable: control::MetaData::channelNumber
         x:

--- a/src/eva/transforms/arithmetic.py
+++ b/src/eva/transforms/arithmetic.py
@@ -19,7 +19,7 @@ from eva.transforms.transform_utils import replace_cgv
 from eva.utilities.utils import remove_list_duplicates
 from eva.utilities.utils import remove_empty_from_list_of_strings
 
-defined_functions = ['log', 'sqrt', 'mean', 'scipy_f_ppf', 'scipy_t_ppf', :2'abs']
+defined_functions = ['log', 'sqrt', 'mean', 'scipy_f_ppf', 'scipy_t_ppf', 'abs']
 
 # --------------------------------------------------------------------------------------------------
 

--- a/src/eva/transforms/arithmetic.py
+++ b/src/eva/transforms/arithmetic.py
@@ -8,19 +8,47 @@
 
 
 # --------------------------------------------------------------------------------------------------
-
-
-from math import sqrt
-from numpy import log
 import re
-from statistics import mean
-
+import scipy
+import xarray as xr
+from numpy import log, sqrt, mean, abs
 from eva.utilities.config import get
 from eva.utilities.logger import Logger
 from eva.transforms.transform_utils import parse_for_dict, split_collectiongroupvariable
 from eva.transforms.transform_utils import replace_cgv
 from eva.utilities.utils import remove_list_duplicates
 from eva.utilities.utils import remove_empty_from_list_of_strings
+
+defined_functions = ['log','sqrt','mean','scipy_f_ppf','scipy_t_ppf','abs']
+
+# --------------------------------------------------------------------------------------------------
+
+
+def scipy_f_ppf(q, df1, df2):
+    """
+    Wraps xarray around scipy to give scipy.stat.f.ppf
+    to get critical value for f test
+    q - confidence interval (1-alpha/2) where alpha is the significance level, with confidence 
+       level being complement (e.g., 1-0.05/2 for a 95% confidence interval)
+    df1 - degree of freedom for 1st distribution (count-1)
+    df2 - degree of freedome for 2nd distribution (count-1)
+    """
+    return xr.apply_ufunc(scipy.stats.f.ppf, q, df1, df2)
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+def scipy_t_ppf(q, df):
+    """
+    Wraps xarray around scipy to give scipy.stat.t.ppf
+    to get critical value for t test
+    q - confidence interval (1-alpha/2 for 2 sided/way, 1-alpha for one sided/way where alpha is
+        significance level (e.g., for 95% confidence interval 1-0.05/2 for two sided/way, or 
+        1-0.05 for one sided/way
+    df - degree of freedom (count - 1)
+    """
+    return xr.apply_ufunc(scipy.stats.t.ppf, q, df)
 
 
 # --------------------------------------------------------------------------------------------------
@@ -107,9 +135,13 @@ def arithmetic(config, data_collections):
 
                 # Remove white space
                 expression = ''.join(expression.split())
-
+              
                 # Split math equation
-                expression_elements = re.split(r'\(|\)|-|\*|\+|\/|log', expression)
+                regex_string = r'\(|\)|-|\*|\+|\/|,'
+                # add defined functions the user may apply
+                for fname in defined_functions:
+                    regex_string += '|{}'.format(fname) 
+                expression_elements = re.split(regex_string, expression)
 
                 # Remove empty elements and duplicates from expression elements
                 expression_elements = remove_empty_from_list_of_strings(expression_elements)
@@ -132,7 +164,6 @@ def arithmetic(config, data_collections):
 
                 # Evaluate the expression
                 new_variable = eval(str(expression))
-
                 # Add the new field to the data collections
                 cgv = split_collectiongroupvariable(logger, new_name)
                 data_collections.add_variable_to_collection(cgv[0], cgv[1], cgv[2], new_variable)

--- a/src/eva/transforms/arithmetic.py
+++ b/src/eva/transforms/arithmetic.py
@@ -19,7 +19,7 @@ from eva.transforms.transform_utils import replace_cgv
 from eva.utilities.utils import remove_list_duplicates
 from eva.utilities.utils import remove_empty_from_list_of_strings
 
-defined_functions = ['log','sqrt','mean','scipy_f_ppf','scipy_t_ppf','abs']
+defined_functions = ['log', 'sqrt', 'mean', 'scipy_f_ppf', 'scipy_t_ppf', :2'abs']
 
 # --------------------------------------------------------------------------------------------------
 
@@ -140,7 +140,7 @@ def arithmetic(config, data_collections):
                 regex_string = r'\(|\)|-|\*|\+|\/|,'
                 # add defined functions the user may apply
                 for fname in defined_functions:
-                    regex_string += '|{}'.format(fname) 
+                    regex_string += '|{}'.format(fname)
                 expression_elements = re.split(regex_string, expression)
 
                 # Remove empty elements and duplicates from expression elements

--- a/src/eva/transforms/arithmetic.py
+++ b/src/eva/transforms/arithmetic.py
@@ -28,7 +28,7 @@ def scipy_f_ppf(q, df1, df2):
     """
     Wraps xarray around scipy to give scipy.stat.f.ppf
     to get critical value for f test
-    q - confidence interval (1-alpha/2) where alpha is the significance level, with confidence 
+    q - confidence interval (1-alpha/2) where alpha is the significance level, with confidence
        level being complement (e.g., 1-0.05/2 for a 95% confidence interval)
     df1 - degree of freedom for 1st distribution (count-1)
     df2 - degree of freedome for 2nd distribution (count-1)
@@ -44,7 +44,7 @@ def scipy_t_ppf(q, df):
     Wraps xarray around scipy to give scipy.stat.t.ppf
     to get critical value for t test
     q - confidence interval (1-alpha/2 for 2 sided/way, 1-alpha for one sided/way where alpha is
-        significance level (e.g., for 95% confidence interval 1-0.05/2 for two sided/way, or 
+        significance level (e.g., for 95% confidence interval 1-0.05/2 for two sided/way, or
         1-0.05 for one sided/way
     df - degree of freedom (count - 1)
     """
@@ -135,7 +135,7 @@ def arithmetic(config, data_collections):
 
                 # Remove white space
                 expression = ''.join(expression.split())
-              
+
                 # Split math equation
                 regex_string = r'\(|\)|-|\*|\+|\/|,'
                 # add defined functions the user may apply


### PR DESCRIPTION
## Description
Wraps some basic scipy functions necessary to compute confidence intervals, and adds an example of adding confidence intervals to channel summary plot.

Provide a detailed description of what this PR does.

Adds `testIodaObsSpaceAmsuaN19_Channel_Stats_Confidence.yaml` which plots a mean OmB with confidence intervals, and a ratio of variance with confidence intervals. 

## Dependencies
None.

## Impact
Modifies arithmetic transform to allow the user to specify wrapped ppf functions from scipy. 

Please list the other repositories (if any) that this PR will require changes in (example below)
None