### PR TITLE
Add filenames_template for use in timeseries plots

### DIFF
--- a/src/eva/tests/config/testIodaObsSpaceAmsuaN19_Multiple_TimeSeries.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceAmsuaN19_Multiple_TimeSeries.yaml
@@ -71,7 +71,7 @@ graphics:
       - 1
       - 1
       title: Mean OmB | AMSU-A NOAA-19 | Ch 3 | ObsValueMinusHofx::brightnessTemperature
-      output name: time_series/amsua_n19/brightnessTemperature_mean/3/time_series_compare_omb_template.png
+      output name: time_series/amsua_n19/brightnessTemperature_mean/3/time_series_compare_omb.png
     plots:
     - add_xlabel: Datetime
       add_ylabel: JEDI h(x)

--- a/src/eva/tests/config/testIodaObsSpaceAmsuaN19_Multiple_TimeSeries.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceAmsuaN19_Multiple_TimeSeries.yaml
@@ -2,21 +2,11 @@ suppress_collection_display: false
 datasets:
 - name: control
   type: IodaObsSpace
-  filenames:
-  - ${data_input_path}/ctrl_amsua_n19.20230726T030000Z.nc4
-  channels: 3,8
-  groups:
-  - name: ObsValue
-    variables:
-    - brightnessTemperature
-  - name: GsiHofXBc
-  - name: hofx0
-  - name: MetaData
-  - name: oman
-- name: control
-  type: IodaObsSpace
-  filenames:
-  - ${data_input_path}/ctrl_amsua_n19.20230726T090000Z.nc4
+  filenames_template:
+    template: ${data_input_path}/ctrl_amsua_n19.%Y%m%dT%H0000Z.nc4
+    start: '2023-07-26T03:00:00'
+    end: '2023-07-26T09:00:00'
+    interval_hours: 6
   channels: 3,8
   groups:
   - name: ObsValue
@@ -27,22 +17,12 @@ datasets:
   - name: MetaData
   - name: oman
 - name: experiment
+  filenames_template: 
+    template: ${data_input_path}/exp_amsua_n19.%Y%m%dT%H0000Z.nc4
+    start: '2023-07-26T03:00:00'
+    end: '2023-07-26T09:00:00'
+    interval_hours: 6
   type: IodaObsSpace
-  filenames:
-  - ${data_input_path}/exp_amsua_n19.20230726T030000Z.nc4
-  channels: 3,8
-  groups:
-  - name: ObsValue
-    variables:
-    - brightnessTemperature
-  - name: GsiHofXBc
-  - name: hofx0
-  - name: MetaData
-  - name: oman
-- name: experiment
-  type: IodaObsSpace
-  filenames:
-  - ${data_input_path}/exp_amsua_n19.20230726T090000Z.nc4
   channels: 3,8
   groups:
   - name: ObsValue
@@ -91,7 +71,7 @@ graphics:
       - 1
       - 1
       title: Mean OmB | AMSU-A NOAA-19 | Ch 3 | ObsValueMinusHofx::brightnessTemperature
-      output name: time_series/amsua_n19/brightnessTemperature_mean/3/time_series_compare_omb.png
+      output name: time_series/amsua_n19/brightnessTemperature_mean/3/time_series_compare_omb_template.png
     plots:
     - add_xlabel: Datetime
       add_ylabel: JEDI h(x)

--- a/src/eva/tests/config/testIodaObsSpaceAmsuaN19_Multiple_TimeSeries.yaml
+++ b/src/eva/tests/config/testIodaObsSpaceAmsuaN19_Multiple_TimeSeries.yaml
@@ -17,7 +17,7 @@ datasets:
   - name: MetaData
   - name: oman
 - name: experiment
-  filenames_template: 
+  filenames_template:
     template: ${data_input_path}/exp_amsua_n19.%Y%m%dT%H0000Z.nc4
     start: '2023-07-26T03:00:00'
     end: '2023-07-26T09:00:00'

--- a/src/eva/time_series/time_series_utils.py
+++ b/src/eva/time_series/time_series_utils.py
@@ -3,7 +3,7 @@ import numpy as np
 import xarray as xr
 from eva.data.data_driver import data_driver
 from eva.data.data_collections import DataCollections
-
+from eva.utilities.utils import generate_filenames_from_template
 
 filename_retrieval = {
     "GsiObsSpace": lambda dataset_config: dataset_config["filenames"],
@@ -14,6 +14,12 @@ filename_retrieval = {
 
 def get_filenames(dataset_config, logger):
     """ Retrieve filenames using given type  """
+
+    if "filenames_template" in dataset_config:
+        dataset_config['filenames'] = generate_filenames_from_template(
+            dataset_config['filenames_template'], logger)
+        del dataset_config['filenames_template']
+
 
     dataset_type = dataset_config["type"]
     logger.assert_abort(dataset_type in filename_retrieval,

--- a/src/eva/time_series/time_series_utils.py
+++ b/src/eva/time_series/time_series_utils.py
@@ -20,7 +20,6 @@ def get_filenames(dataset_config, logger):
             dataset_config['filenames_template'], logger)
         del dataset_config['filenames_template']
 
-
     dataset_type = dataset_config["type"]
     logger.assert_abort(dataset_type in filename_retrieval,
                         f'Unknown dataset_type {dataset_type}')


### PR DESCRIPTION
## Description

Add capability to use filenames_template to timeseries plots. 

## Dependencies
None 

## Impact
Changes a test to use timeseries template in place of explicitly using filenames. 
